### PR TITLE
Amend SONARPHP-1278

### DIFF
--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/ast/GroupTree.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/ast/GroupTree.java
@@ -30,7 +30,8 @@ public abstract class GroupTree extends RegexTree {
   private final RegexTree.Kind kind;
 
   /**
-   * Can only be null for non-capturing groups
+   * Can only be null for non-capturing groups (by design).
+   * If non-null - it represents an empty group iff `element` is a SequenceTree with empty `items` list.
    */
   @Nullable
   protected final RegexTree element;

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/finders/EmptyGroupFinder.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/finders/EmptyGroupFinder.java
@@ -1,0 +1,63 @@
+/*
+ * SonarSource Analyzers Regex Parsing Commons
+ * Copyright (C) 2009-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.analyzer.commons.regex.finders;
+
+import org.sonarsource.analyzer.commons.regex.RegexIssueReporter;
+import org.sonarsource.analyzer.commons.regex.ast.*;
+
+import java.util.Collections;
+
+
+public class EmptyGroupFinder extends RegexBaseVisitor {
+  private static final String MESSAGE = "Remove this empty group.";
+
+  private final RegexIssueReporter.ElementIssue regexElementIssueReporter;
+
+  public EmptyGroupFinder(RegexIssueReporter.ElementIssue regexElementIssueReporter) {
+    this.regexElementIssueReporter = regexElementIssueReporter;
+  }
+
+  private void visitGroupTree(GroupTree groupTree) {
+    RegexTree element = groupTree.getElement();
+    // Question: Is SequenceTree the only Tree type that may be parsed from <empty> Regex literal?
+    //           If not - we should also handle the other possibilities here:
+    if (element == null
+        || element instanceof SequenceTree && ((SequenceTree) element).getItems().isEmpty()) {
+      regexElementIssueReporter.report(groupTree, MESSAGE, null, Collections.emptyList());
+    } else {
+      visit(element);
+    }
+  }
+
+  @Override
+  public void visitCapturingGroup(CapturingGroupTree tree) {
+    visitGroupTree(tree);
+  }
+
+  @Override
+  public void visitNonCapturingGroup(NonCapturingGroupTree tree) {
+    visitGroupTree(tree);
+  }
+
+  @Override
+  public void visitAtomicGroup(AtomicGroupTree tree) {
+    visitGroupTree(tree);
+  }
+}

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/finders/EmptyGroupFinder.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/finders/EmptyGroupFinder.java
@@ -20,7 +20,14 @@
 package org.sonarsource.analyzer.commons.regex.finders;
 
 import org.sonarsource.analyzer.commons.regex.RegexIssueReporter;
-import org.sonarsource.analyzer.commons.regex.ast.*;
+import org.sonarsource.analyzer.commons.regex.ast.GroupTree;
+import org.sonarsource.analyzer.commons.regex.ast.RegexBaseVisitor;
+import org.sonarsource.analyzer.commons.regex.ast.RegexTree;
+import org.sonarsource.analyzer.commons.regex.ast.SequenceTree;
+import org.sonarsource.analyzer.commons.regex.ast.AtomicGroupTree;
+import org.sonarsource.analyzer.commons.regex.ast.CapturingGroupTree;
+import org.sonarsource.analyzer.commons.regex.ast.NonCapturingGroupTree;
+import org.sonarsource.analyzer.commons.regex.ast.LookAroundTree;
 
 import java.util.Collections;
 
@@ -36,10 +43,8 @@ public class EmptyGroupFinder extends RegexBaseVisitor {
 
   private void visitGroupTree(GroupTree groupTree) {
     RegexTree element = groupTree.getElement();
-    // Question: Is SequenceTree the only Tree type that may be parsed from <empty> Regex literal?
-    //           If not - we should also handle the other possibilities here:
     if (element == null
-        || element instanceof SequenceTree && ((SequenceTree) element).getItems().isEmpty()) {
+      || (element instanceof SequenceTree && ((SequenceTree) element).getItems().isEmpty())) {
       regexElementIssueReporter.report(groupTree, MESSAGE, null, Collections.emptyList());
     } else {
       visit(element);
@@ -58,6 +63,11 @@ public class EmptyGroupFinder extends RegexBaseVisitor {
 
   @Override
   public void visitAtomicGroup(AtomicGroupTree tree) {
+    visitGroupTree(tree);
+  }
+
+  @Override
+  public void visitLookAround(LookAroundTree tree) {
     visitGroupTree(tree);
   }
 }

--- a/regex-parsing/src/test/java/org/sonarsource/analyzer/commons/regex/finders/EmptyGroupFinderTest.java
+++ b/regex-parsing/src/test/java/org/sonarsource/analyzer/commons/regex/finders/EmptyGroupFinderTest.java
@@ -1,0 +1,40 @@
+/*
+ * SonarSource Analyzers Regex Parsing Commons
+ * Copyright (C) 2009-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.analyzer.commons.regex.finders;
+
+import org.junit.jupiter.api.Test;
+import org.sonarsource.analyzer.commons.regex.RegexIssueReporter;
+import org.sonarsource.analyzer.commons.regex.RegexParseResult;
+
+class EmptyGroupFinderTest {
+
+  @Test
+  void test() {
+    Verifier.verify(new EmptyGroupFinderCheck(), "EmptyGroupFinder.yml");
+  }
+
+  static class EmptyGroupFinderCheck extends FinderCheck {
+    @Override
+    public void checkRegex(RegexParseResult parseResult, RegexIssueReporter.ElementIssue regexElementIssueReporter, RegexIssueReporter.InvocationIssue invocationIssueReporter) {
+      new EmptyGroupFinder(regexElementIssueReporter).visit(parseResult);
+    }
+  }
+
+}

--- a/regex-parsing/src/test/resources/finders/EmptyGroupFinder.yml
+++ b/regex-parsing/src/test/resources/finders/EmptyGroupFinder.yml
@@ -1,0 +1,13 @@
+- 'foo()bar'   # Noncompliant {{Remove this empty group.}}
+- 'foo(?:)bar' # Noncompliant
+- 'foo(?>)bar' # Noncompliant
+- '(foo()bar)'   # Noncompliant
+- '(foo(?:)bar)' # Noncompliant
+- '(foo(?>)bar)' # Noncompliant
+
+- '[foo()bar]'   # Compliant
+- '[foo(?:)bar]' # Compliant
+- '[foo(?>)bar]' # Compliant
+- '(foo(|)bar)'   # Compliant
+- '(foo(?:|)bar)' # Compliant
+- '(foo(?>|)bar)' # Compliant

--- a/regex-parsing/src/test/resources/finders/EmptyGroupFinder.yml
+++ b/regex-parsing/src/test/resources/finders/EmptyGroupFinder.yml
@@ -1,13 +1,39 @@
 - 'foo()bar'   # Noncompliant {{Remove this empty group.}}
 - 'foo(?:)bar' # Noncompliant
 - 'foo(?>)bar' # Noncompliant
+- 'foo(?=)bar' # Noncompliant
+- 'foo(?!)bar' # Noncompliant
+- 'foo(?<=)bar' # Noncompliant
+- 'foo(?<!)bar' # Noncompliant
+
 - '(foo()bar)'   # Noncompliant
 - '(foo(?:)bar)' # Noncompliant
 - '(foo(?>)bar)' # Noncompliant
+- '(foo(?=)bar)' # Noncompliant
+- '(foo(?!)bar)' # Noncompliant
+- '(foo(?<=)bar)' # Noncompliant
+- '(foo(?<!)bar)' # Noncompliant
+
+- 'foo(x)bar'   # Compliant
+- 'foo(?:x)bar' # Compliant
+- 'foo(?>x)bar' # Compliant
+- 'foo(?=x)bar' # Compliant
+- 'foo(?!x)bar' # Compliant
+- 'foo(?<=x)bar' # Compliant
+- 'foo(?<!x)bar' # Compliant
 
 - '[foo()bar]'   # Compliant
 - '[foo(?:)bar]' # Compliant
 - '[foo(?>)bar]' # Compliant
+- '[foo(?=x)bar]' # Compliant
+- '[foo(?!x)bar]' # Compliant
+- '[foo(?<=x)bar]' # Compliant
+- '[foo(?<!x)bar]' # Compliant
+
 - '(foo(|)bar)'   # Compliant
 - '(foo(?:|)bar)' # Compliant
 - '(foo(?>|)bar)' # Compliant
+- '(foo(?=|)bar)' # Compliant
+- '(foo(?!|)bar)' # Compliant
+- '(foo(?<=|)bar)' # Compliant
+- '(foo(?<!|)bar)' # Compliant

--- a/regex-parsing/src/test/resources/finders/EmptyGroupFinder.yml
+++ b/regex-parsing/src/test/resources/finders/EmptyGroupFinder.yml
@@ -1,4 +1,6 @@
 - 'foo()bar'   # Noncompliant {{Remove this empty group.}}
+- 'foo(?-)bar' # Noncompliant
+- 'foo(?-x)bar' # Noncompliant
 - 'foo(?:)bar' # Noncompliant
 - 'foo(?>)bar' # Noncompliant
 - 'foo(?=)bar' # Noncompliant
@@ -7,6 +9,7 @@
 - 'foo(?<!)bar' # Noncompliant
 
 - '(foo()bar)'   # Noncompliant
+- '(foo(?-)bar)' # Noncompliant
 - '(foo(?:)bar)' # Noncompliant
 - '(foo(?>)bar)' # Noncompliant
 - '(foo(?=)bar)' # Noncompliant
@@ -23,6 +26,7 @@
 - 'foo(?<!x)bar' # Compliant
 
 - '[foo()bar]'   # Compliant
+- '[foo(?-)bar]' # Compliant
 - '[foo(?:)bar]' # Compliant
 - '[foo(?>)bar]' # Compliant
 - '[foo(?=x)bar]' # Compliant
@@ -31,6 +35,7 @@
 - '[foo(?<!x)bar]' # Compliant
 
 - '(foo(|)bar)'   # Compliant
+- '(foo(?-|)bar)' # Compliant
 - '(foo(?:|)bar)' # Compliant
 - '(foo(?>|)bar)' # Compliant
 - '(foo(?=|)bar)' # Compliant


### PR DESCRIPTION
Modifiers are represented in the AST as NonCapturingGroup with element = null.
Don't treat those like empty-non capturing groups (they are not!) and don't raise S6331