### PR TITLE
fix EmptyGroupFinder so it does not report modifiers as an empty group

### DIFF
--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/finders/EmptyGroupFinder.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/finders/EmptyGroupFinder.java
@@ -43,11 +43,12 @@ public class EmptyGroupFinder extends RegexBaseVisitor {
 
   private void visitGroupTree(GroupTree groupTree) {
     RegexTree element = groupTree.getElement();
-    if (element == null
-      || (element instanceof SequenceTree && ((SequenceTree) element).getItems().isEmpty())) {
-      regexElementIssueReporter.report(groupTree, MESSAGE, null, Collections.emptyList());
-    } else {
-      visit(element);
+    if (element != null) {
+      if (element instanceof SequenceTree && ((SequenceTree) element).getItems().isEmpty()) {
+        regexElementIssueReporter.report(groupTree, MESSAGE, null, Collections.emptyList());
+      } else {
+        super.visit(element);
+      }
     }
   }
 

--- a/regex-parsing/src/test/resources/finders/EmptyGroupFinder.yml
+++ b/regex-parsing/src/test/resources/finders/EmptyGroupFinder.yml
@@ -1,6 +1,4 @@
 - 'foo()bar'   # Noncompliant {{Remove this empty group.}}
-- 'foo(?-)bar' # Noncompliant
-- 'foo(?-x)bar' # Noncompliant
 - 'foo(?:)bar' # Noncompliant
 - 'foo(?>)bar' # Noncompliant
 - 'foo(?=)bar' # Noncompliant
@@ -9,13 +7,17 @@
 - 'foo(?<!)bar' # Noncompliant
 
 - '(foo()bar)'   # Noncompliant
-- '(foo(?-)bar)' # Noncompliant
 - '(foo(?:)bar)' # Noncompliant
 - '(foo(?>)bar)' # Noncompliant
 - '(foo(?=)bar)' # Noncompliant
 - '(foo(?!)bar)' # Noncompliant
 - '(foo(?<=)bar)' # Noncompliant
 - '(foo(?<!)bar)' # Noncompliant
+
+# modifiers:
+- 'foo(?-)bar' # Compliant
+- 'foo(?-x)bar' # Compliant
+- '(foo(?-)bar)' # Compliant
 
 - 'foo(x)bar'   # Compliant
 - 'foo(?:x)bar' # Compliant


### PR DESCRIPTION
Modifiers are represented in the AST as NonCapturingGroup with element = null.
Don't treat those like empty-non capturing groups (they are not!) and don't raise S6331