### PR TITLE
Use "MatchType" to improve precision of S6002 finder

### DIFF
--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/finders/FailingLookaheadFinder.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/finders/FailingLookaheadFinder.java
@@ -20,6 +20,7 @@
 package org.sonarsource.analyzer.commons.regex.finders;
 
 import java.util.Collections;
+import org.sonarsource.analyzer.commons.regex.MatchType;
 import org.sonarsource.analyzer.commons.regex.RegexIssueReporter;
 import org.sonarsource.analyzer.commons.regex.ast.FinalState;
 import org.sonarsource.analyzer.commons.regex.ast.LookAroundTree;
@@ -34,10 +35,16 @@ public class FailingLookaheadFinder extends RegexBaseVisitor {
 
   private final RegexIssueReporter.ElementIssue regexElementIssueReporter;
   private final FinalState finalState;
+  private final MatchType matchType;
 
   public FailingLookaheadFinder(RegexIssueReporter.ElementIssue regexElementIssueReporter, FinalState finalState) {
+    this(regexElementIssueReporter, finalState, MatchType.NOT_SUPPORTED);
+  }
+
+  public FailingLookaheadFinder(RegexIssueReporter.ElementIssue regexElementIssueReporter, FinalState finalState, MatchType matchType) {
     this.regexElementIssueReporter = regexElementIssueReporter;
     this.finalState = finalState;
+    this.matchType = matchType;
   }
 
   @Override
@@ -57,7 +64,8 @@ public class FailingLookaheadFinder extends RegexBaseVisitor {
       lookAroundSubAutomaton = new SubAutomaton(lookAroundElement, lookAroundElement.continuation(), false);
       return RegexTreeHelper.supersetOf(lookAroundSubAutomaton, continuationSubAutomaton, false);
     }
-    lookAroundSubAutomaton = new SubAutomaton(lookAroundElement, lookAroundElement.continuation(), true);
+    boolean canLookAroundBeAPrefix = matchType != MatchType.FULL;
+    lookAroundSubAutomaton = new SubAutomaton(lookAroundElement, lookAroundElement.continuation(), canLookAroundBeAPrefix);
     return !RegexTreeHelper.intersects(lookAroundSubAutomaton, continuationSubAutomaton, true);
   }
 }

--- a/regex-parsing/src/test/java/org/sonarsource/analyzer/commons/regex/finders/FailingLookaheadFinderTest.java
+++ b/regex-parsing/src/test/java/org/sonarsource/analyzer/commons/regex/finders/FailingLookaheadFinderTest.java
@@ -20,20 +20,55 @@
 package org.sonarsource.analyzer.commons.regex.finders;
 
 import org.junit.jupiter.api.Test;
+import org.sonarsource.analyzer.commons.regex.MatchType;
 import org.sonarsource.analyzer.commons.regex.RegexIssueReporter;
 import org.sonarsource.analyzer.commons.regex.RegexParseResult;
 
 class FailingLookaheadFinderTest {
 
+  // The behavior should be the same for Partial, Both, Unknown and Not Supported.
   @Test
   void test() {
     Verifier.verify(new FailingLookaheadFinderCheck(), "FailingLookaheadFinder.yml");
+  }
+
+  @Test
+  void test_partial_match() {
+    Verifier.verify(new FailingLookaheadFinderCheckWithMatchType(MatchType.PARTIAL), "FailingLookaheadFinder.yml");
+  }
+
+  @Test
+  void test_unknown_match() {
+    Verifier.verify(new FailingLookaheadFinderCheckWithMatchType(MatchType.UNKNOWN), "FailingLookaheadFinder.yml");
+  }
+
+  @Test
+  void test_both_match() {
+    Verifier.verify(new FailingLookaheadFinderCheckWithMatchType(MatchType.BOTH), "FailingLookaheadFinder.yml");
+  }
+
+  @Test
+  void test_full_match() {
+    Verifier.verify(new FailingLookaheadFinderCheckWithMatchType(MatchType.FULL), "FailingLookaheadFinderFullMatch.yml");
   }
 
   static class FailingLookaheadFinderCheck extends FinderCheck {
     @Override
     public void checkRegex(RegexParseResult parseResult, RegexIssueReporter.ElementIssue regexElementIssueReporter, RegexIssueReporter.InvocationIssue invocationIssueReporter) {
       new FailingLookaheadFinder(regexElementIssueReporter, parseResult.getFinalState()).visit(parseResult);
+    }
+  }
+
+  static class FailingLookaheadFinderCheckWithMatchType extends FinderCheck {
+    private final MatchType matchType;
+
+    FailingLookaheadFinderCheckWithMatchType(MatchType matchType) {
+      this.matchType = matchType;
+    }
+
+    @Override
+    public void checkRegex(RegexParseResult parseResult, RegexIssueReporter.ElementIssue regexElementIssueReporter, RegexIssueReporter.InvocationIssue invocationIssueReporter) {
+      new FailingLookaheadFinder(regexElementIssueReporter, parseResult.getFinalState(), matchType).visit(parseResult);
     }
   }
 

--- a/regex-parsing/src/test/resources/finders/FailingLookaheadFinderFullMatch.yml
+++ b/regex-parsing/src/test/resources/finders/FailingLookaheadFinderFullMatch.yml
@@ -12,6 +12,7 @@
 - '(?=a)ab'
 - '(?!ab)..'
 - '(?<=a)b'
-- 'a(?=b)'
-- '(?=abc)ab'
-- '(?!abc)ab'
+# Additional issue compared to other match type: this can never match because the "ab" can not be a prefix of the lookaround
+- 'a(?=b)' # Noncompliant
+- '(?=abc)ab' # Noncompliant
+- '(?!abc)ab' # Compliant: negative lookahead are not impacted by the match type


### PR DESCRIPTION
Fix #227.