### PR TITLE
Fix intersection/superset of lookahead and possessive quantifiers inside of a repetition

### DIFF
--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/ast/AutomatonState.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/ast/AutomatonState.java
@@ -37,6 +37,10 @@ public interface AutomatonState {
     return Collections.singletonList(continuation());
   }
 
+  default boolean isBeginningLowerThan(int offset, boolean defaultValue) {
+    return defaultValue;
+  }
+
   @Nonnull
   TransitionType incomingTransitionType();
 

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/ast/AutomatonState.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/ast/AutomatonState.java
@@ -21,6 +21,7 @@ package org.sonarsource.analyzer.commons.regex.ast;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -37,8 +38,8 @@ public interface AutomatonState {
     return Collections.singletonList(continuation());
   }
 
-  default boolean isBeginningLowerThan(int offset, boolean defaultValue) {
-    return defaultValue;
+  default Optional<RegexTree> toRegexTree() {
+    return Optional.empty();
   }
 
   @Nonnull

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/ast/IndexRange.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/ast/IndexRange.java
@@ -31,6 +31,10 @@ public class IndexRange {
     this.endingOffset = endingOffset;
   }
 
+  public static IndexRange inaccessible() {
+    return new IndexRange(-1, -1);
+  }
+
   public int getBeginningOffset() {
     return beginningOffset;
   }
@@ -45,6 +49,10 @@ public class IndexRange {
 
   public IndexRange extendTo(int newEnd) {
     return new IndexRange(beginningOffset, newEnd);
+  }
+
+  public boolean contains(IndexRange other) {
+    return this.beginningOffset <= other.beginningOffset && other.endingOffset <= this.endingOffset;
   }
 
   @Override

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/ast/RegexTree.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/ast/RegexTree.java
@@ -72,6 +72,11 @@ public abstract class RegexTree extends AbstractRegexSyntaxElement implements Au
     return false;
   }
 
+  @Override
+  public boolean isBeginningLowerThan(int offset, boolean defaultValue) {
+    return this.getRange().getBeginningOffset() < offset;
+  }
+
   private AutomatonState continuation;
 
   @Nonnull

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/ast/RegexTree.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/ast/RegexTree.java
@@ -19,6 +19,7 @@
  */
 package org.sonarsource.analyzer.commons.regex.ast;
 
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import org.sonarsource.analyzer.commons.regex.RegexSource;
 
@@ -73,8 +74,8 @@ public abstract class RegexTree extends AbstractRegexSyntaxElement implements Au
   }
 
   @Override
-  public boolean isBeginningLowerThan(int offset, boolean defaultValue) {
-    return this.getRange().getBeginningOffset() < offset;
+  public Optional<RegexTree> toRegexTree() {
+    return Optional.of(this);
   }
 
   private AutomatonState continuation;

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/finders/FailingLookaheadFinder.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/finders/FailingLookaheadFinder.java
@@ -57,15 +57,16 @@ public class FailingLookaheadFinder extends RegexBaseVisitor {
 
   private boolean doesLookaheadContinuationAlwaysFail(LookAroundTree lookAround) {
     RegexTree lookAroundElement = lookAround.getElement();
+    int lowerBound = lookAround.getRange().getBeginningOffset();
     SubAutomaton lookAroundSubAutomaton;
-    SubAutomaton continuationSubAutomaton = new SubAutomaton(lookAround.continuation(), finalState, true);
+    SubAutomaton continuationSubAutomaton = new SubAutomaton(lookAround.continuation(), finalState, lowerBound, true);
 
     if (lookAround.getPolarity() == LookAroundTree.Polarity.NEGATIVE) {
-      lookAroundSubAutomaton = new SubAutomaton(lookAroundElement, lookAroundElement.continuation(), false);
+      lookAroundSubAutomaton = new SubAutomaton(lookAroundElement, lookAroundElement.continuation(), lowerBound, false);
       return RegexTreeHelper.supersetOf(lookAroundSubAutomaton, continuationSubAutomaton, false);
     }
     boolean canLookAroundBeAPrefix = matchType != MatchType.FULL;
-    lookAroundSubAutomaton = new SubAutomaton(lookAroundElement, lookAroundElement.continuation(), canLookAroundBeAPrefix);
+    lookAroundSubAutomaton = new SubAutomaton(lookAroundElement, lookAroundElement.continuation(), lowerBound, canLookAroundBeAPrefix);
     return !RegexTreeHelper.intersects(lookAroundSubAutomaton, continuationSubAutomaton, true);
   }
 }

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/finders/PossessiveQuantifierContinuationFinder.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/finders/PossessiveQuantifierContinuationFinder.java
@@ -25,13 +25,13 @@ import org.sonarsource.analyzer.commons.regex.RegexIssueReporter;
 import org.sonarsource.analyzer.commons.regex.ast.AutomatonState;
 import org.sonarsource.analyzer.commons.regex.ast.FinalState;
 import org.sonarsource.analyzer.commons.regex.ast.Quantifier;
-import org.sonarsource.analyzer.commons.regex.ast.RegexBaseVisitor;
 import org.sonarsource.analyzer.commons.regex.ast.RegexSyntaxElement;
 import org.sonarsource.analyzer.commons.regex.ast.RepetitionTree;
+import org.sonarsource.analyzer.commons.regex.helpers.BranchTrackingVisitor;
 import org.sonarsource.analyzer.commons.regex.helpers.RegexTreeHelper;
 import org.sonarsource.analyzer.commons.regex.helpers.SubAutomaton;
 
-public class PossessiveQuantifierContinuationFinder extends RegexBaseVisitor {
+public class PossessiveQuantifierContinuationFinder extends BranchTrackingVisitor {
 
   private static final String MESSAGE = "Change this impossible to match sub-pattern that conflicts with the previous possessive quantifier.";
 
@@ -58,12 +58,12 @@ public class PossessiveQuantifierContinuationFinder extends RegexBaseVisitor {
 
   private boolean doesRepetitionContinuationAlwaysFail(RepetitionTree repetitionTree) {
     Quantifier quantifier = repetitionTree.getQuantifier();
-    int lowerBound = repetitionTree.getRange().getBeginningOffset();
     if (!quantifier.isOpenEnded() || quantifier.getModifier() != Quantifier.Modifier.POSSESSIVE) {
       return false;
     }
-    SubAutomaton potentialSuperset = new SubAutomaton(repetitionTree.getElement(), repetitionTree.getElement().continuation(), lowerBound, false);
-    SubAutomaton potentialSubset = new SubAutomaton(repetitionTree.continuation(), finalState, lowerBound, true);
+
+    SubAutomaton potentialSuperset = new SubAutomaton(repetitionTree.getElement(), repetitionTree.getElement().continuation(), false);
+    SubAutomaton potentialSubset = new SubAutomaton(repetitionTree.continuation(), finalState, getBranchRangeFor(repetitionTree), true);
     return RegexTreeHelper.supersetOf(potentialSuperset, potentialSubset, false);
   }
 }

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/finders/PossessiveQuantifierContinuationFinder.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/finders/PossessiveQuantifierContinuationFinder.java
@@ -58,11 +58,12 @@ public class PossessiveQuantifierContinuationFinder extends RegexBaseVisitor {
 
   private boolean doesRepetitionContinuationAlwaysFail(RepetitionTree repetitionTree) {
     Quantifier quantifier = repetitionTree.getQuantifier();
+    int lowerBound = repetitionTree.getRange().getBeginningOffset();
     if (!quantifier.isOpenEnded() || quantifier.getModifier() != Quantifier.Modifier.POSSESSIVE) {
       return false;
     }
-    SubAutomaton potentialSuperset = new SubAutomaton(repetitionTree.getElement(), repetitionTree.continuation(), false);
-    SubAutomaton potentialSubset = new SubAutomaton(repetitionTree.continuation(), finalState, true);
+    SubAutomaton potentialSuperset = new SubAutomaton(repetitionTree.getElement(), repetitionTree.getElement().continuation(), lowerBound, false);
+    SubAutomaton potentialSubset = new SubAutomaton(repetitionTree.continuation(), finalState, lowerBound, true);
     return RegexTreeHelper.supersetOf(potentialSuperset, potentialSubset, false);
   }
 }

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/BranchTrackingVisitor.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/BranchTrackingVisitor.java
@@ -34,7 +34,7 @@ import org.sonarsource.analyzer.commons.regex.ast.RepetitionTree;
  * cycles during Automaton evaluation.
  */
 public class BranchTrackingVisitor extends RegexBaseVisitor {
-  private Deque<RegexTree> branchingNodes = new ArrayDeque<>();
+  private final Deque<RegexTree> branchingNodes = new ArrayDeque<>();
 
   @Override
   public void visitDisjunction(DisjunctionTree tree) {

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/BranchTrackingVisitor.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/BranchTrackingVisitor.java
@@ -21,7 +21,6 @@ package org.sonarsource.analyzer.commons.regex.helpers;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.Stack;
 import org.sonarsource.analyzer.commons.regex.ast.AbstractRegexSyntaxElement;
 import org.sonarsource.analyzer.commons.regex.ast.DisjunctionTree;
 import org.sonarsource.analyzer.commons.regex.ast.IndexRange;

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/BranchTrackingVisitor.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/BranchTrackingVisitor.java
@@ -1,0 +1,67 @@
+/*
+ * SonarSource Analyzers Regex Parsing Commons
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.analyzer.commons.regex.helpers;
+
+import org.sonarsource.analyzer.commons.regex.ast.AbstractRegexSyntaxElement;
+import org.sonarsource.analyzer.commons.regex.ast.DisjunctionTree;
+import org.sonarsource.analyzer.commons.regex.ast.IndexRange;
+import org.sonarsource.analyzer.commons.regex.ast.RegexBaseVisitor;
+import org.sonarsource.analyzer.commons.regex.ast.RegexTree;
+import org.sonarsource.analyzer.commons.regex.ast.RepetitionTree;
+
+/**
+ * The BranchTrackingVisitor saves the latest branching nodes as it traverses the tree. This is useful to avoid
+ * cycles during Automaton evaluation.
+ */
+public class BranchTrackingVisitor extends RegexBaseVisitor {
+  private RegexTree closestBranchingNode = null;
+
+  @Override
+  public void visitDisjunction(DisjunctionTree tree) {
+    closestBranchingNode = tree;
+    super.visitDisjunction(tree);
+  }
+
+  @Override
+  public void visitRepetition(RepetitionTree tree) {
+    closestBranchingNode = tree;
+    super.visitRepetition(tree);
+  }
+
+  /**
+   * Return the range of a node's branch. A branch is a group of nodes which are always traversed together by the
+   * automaton.
+   * @param tree a node
+   * @return IndexRange of the node's branch.
+   */
+  public IndexRange getBranchRangeFor(RegexTree tree) {
+    if (closestBranchingNode == null) {
+      return IndexRange.inaccessible();
+    } else if (closestBranchingNode.is(RegexTree.Kind.REPETITION)) {
+      return ((RepetitionTree) closestBranchingNode).getElement().getRange();
+    } else {
+      return ((DisjunctionTree) closestBranchingNode).getAlternatives().stream()
+        .filter(alternative -> alternative.getRange().contains(tree.getRange()))
+        .findFirst()
+        .map(AbstractRegexSyntaxElement::getRange)
+        .orElse(IndexRange.inaccessible());
+    }
+  }
+}

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/IntersectAutomataChecker.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/IntersectAutomataChecker.java
@@ -36,20 +36,20 @@ public class IntersectAutomataChecker extends AbstractAutomataChecker {
     SimplifiedRegexCharacterClass characterClass2 = SimplifiedRegexCharacterClass.of(auto2.start);
     return ((characterClass1 != null) && (characterClass2 != null)) ?
       (characterClass1.intersects(characterClass2, defaultAnswer) &&
-        auto1.successorsAutomata().anyMatch(successor1 ->
-          auto2.successorsAutomata().anyMatch(successor2 ->
+        auto1.anySuccessorMatch(successor1 ->
+          auto2.anySuccessorMatch(successor2 ->
             check(successor1, successor2, true)))
       ) : defaultAnswer;
   }
 
   @Override
   protected boolean checkAuto1Successors(SubAutomaton auto1, SubAutomaton auto2, boolean defaultAnswer, boolean hasConsumedInput) {
-    return auto1.successorsAutomata().anyMatch(successor -> check(successor, auto2, hasConsumedInput));
+    return auto1.anySuccessorMatch(successor -> check(successor, auto2, hasConsumedInput));
   }
 
   @Override
   protected boolean checkAuto2Successors(SubAutomaton auto1, SubAutomaton auto2, boolean defaultAnswer, boolean hasConsumedInput) {
-    return auto2.successorsAutomata().anyMatch(successor -> check(auto1, successor, hasConsumedInput));
+    return auto2.anySuccessorMatch(successor -> check(auto1, successor, hasConsumedInput));
   }
 }
 

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/IntersectAutomataChecker.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/IntersectAutomataChecker.java
@@ -36,19 +36,20 @@ public class IntersectAutomataChecker extends AbstractAutomataChecker {
     SimplifiedRegexCharacterClass characterClass2 = SimplifiedRegexCharacterClass.of(auto2.start);
     return ((characterClass1 != null) && (characterClass2 != null)) ?
       (characterClass1.intersects(characterClass2, defaultAnswer) &&
-        auto1.anySuccessorMatch(successor1 -> auto2.anySuccessorMatch(successor2 ->
-          check(successor1, successor2, true)))) :
-      defaultAnswer;
+        auto1.successorsAutomata().anyMatch(successor1 ->
+          auto2.successorsAutomata().anyMatch(successor2 ->
+            check(successor1, successor2, true)))
+      ) : defaultAnswer;
   }
 
   @Override
   protected boolean checkAuto1Successors(SubAutomaton auto1, SubAutomaton auto2, boolean defaultAnswer, boolean hasConsumedInput) {
-    return auto1.anySuccessorMatch(successor -> check(successor, auto2, hasConsumedInput));
+    return auto1.successorsAutomata().anyMatch(successor -> check(successor, auto2, hasConsumedInput));
   }
 
   @Override
   protected boolean checkAuto2Successors(SubAutomaton auto1, SubAutomaton auto2, boolean defaultAnswer, boolean hasConsumedInput) {
-    return auto2.anySuccessorMatch(successor -> check(auto1, successor, hasConsumedInput));
+    return auto2.successorsAutomata().anyMatch(successor -> check(auto1, successor, hasConsumedInput));
   }
 }
 

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/SubAutomaton.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/SubAutomaton.java
@@ -20,10 +20,9 @@
 package org.sonarsource.analyzer.commons.regex.helpers;
 
 import java.util.Objects;
-import java.util.function.Predicate;
+import java.util.stream.Stream;
 import org.sonarsource.analyzer.commons.regex.ast.AutomatonState;
 import org.sonarsource.analyzer.commons.regex.ast.AutomatonState.TransitionType;
-import org.sonarsource.analyzer.commons.regex.ast.RegexTree;
 
 public class SubAutomaton {
   public final AutomatonState start;
@@ -50,22 +49,10 @@ public class SubAutomaton {
     return start == end;
   }
 
-  public boolean anySuccessorMatch(Predicate<SubAutomaton> predicate) {
-    for (AutomatonState successor : start.successors()) {
-      if (!successor.isBeginningLowerThan(lowerBound, false) && predicate.test(new SubAutomaton(successor, end, lowerBound, allowPrefix))) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  public boolean allSuccessorMatch(Predicate<SubAutomaton> predicate) {
-    for (AutomatonState successor : start.successors()) {
-      if (!successor.isBeginningLowerThan(lowerBound, false) && !predicate.test(new SubAutomaton(successor, end, lowerBound, allowPrefix))) {
-        return false;
-      }
-    }
-    return true;
+  public Stream<SubAutomaton> successorsAutomata() {
+    return start.successors().stream()
+      .filter(successor -> !successor.isBeginningLowerThan(lowerBound, false))
+      .map(successor -> new SubAutomaton(successor, end, lowerBound, allowPrefix));
   }
 
   @Override
@@ -74,13 +61,14 @@ public class SubAutomaton {
     if (o == null || getClass() != o.getClass()) return false;
     SubAutomaton automaton = (SubAutomaton) o;
     return allowPrefix == automaton.allowPrefix &&
+      lowerBound == automaton.lowerBound &&
       Objects.equals(start, automaton.start) &&
       Objects.equals(end, automaton.end);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(start, end, allowPrefix);
+    return Objects.hash(start, end, lowerBound, allowPrefix);
   }
 }
 

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/SubAutomaton.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/SubAutomaton.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import java.util.stream.Stream;
 import org.sonarsource.analyzer.commons.regex.ast.AutomatonState;
 import org.sonarsource.analyzer.commons.regex.ast.AutomatonState.TransitionType;
+import org.sonarsource.analyzer.commons.regex.ast.RegexTree;
+import org.sonarsource.analyzer.commons.regex.ast.RepetitionTree;
 
 public class SubAutomaton {
   public final AutomatonState start;
@@ -51,7 +53,9 @@ public class SubAutomaton {
 
   public Stream<SubAutomaton> successorsAutomata() {
     return start.successors().stream()
-      .filter(successor -> !successor.isBeginningLowerThan(lowerBound, false))
+      .filter(successor ->
+        successor.toRegexTree().filter(tree -> tree.is(RegexTree.Kind.REPETITION)).isPresent() ||
+        successor.toRegexTree().map(tree -> tree.getRange().getBeginningOffset() >= lowerBound).orElse(true))
       .map(successor -> new SubAutomaton(successor, end, lowerBound, allowPrefix));
   }
 

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/SubAutomaton.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/SubAutomaton.java
@@ -23,16 +23,23 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import org.sonarsource.analyzer.commons.regex.ast.AutomatonState;
 import org.sonarsource.analyzer.commons.regex.ast.AutomatonState.TransitionType;
+import org.sonarsource.analyzer.commons.regex.ast.RegexTree;
 
 public class SubAutomaton {
   public final AutomatonState start;
   public final AutomatonState end;
   public final boolean allowPrefix;
+  public final int lowerBound;
 
   public SubAutomaton(AutomatonState start, AutomatonState end, boolean allowPrefix) {
+    this(start, end, -1, allowPrefix);
+  }
+
+  public SubAutomaton(AutomatonState start, AutomatonState end, int lowerBound, boolean allowPrefix) {
     this.start = start;
     this.end = end;
     this.allowPrefix = allowPrefix;
+    this.lowerBound = lowerBound;
   }
 
   public TransitionType incomingTransitionType() {
@@ -45,7 +52,7 @@ public class SubAutomaton {
 
   public boolean anySuccessorMatch(Predicate<SubAutomaton> predicate) {
     for (AutomatonState successor : start.successors()) {
-      if (predicate.test(new SubAutomaton(successor, end, allowPrefix))) {
+      if (!successor.isBeginningLowerThan(lowerBound, false) && predicate.test(new SubAutomaton(successor, end, lowerBound, allowPrefix))) {
         return true;
       }
     }
@@ -54,7 +61,7 @@ public class SubAutomaton {
 
   public boolean allSuccessorMatch(Predicate<SubAutomaton> predicate) {
     for (AutomatonState successor : start.successors()) {
-      if (!predicate.test(new SubAutomaton(successor, end, allowPrefix))) {
+      if (!successor.isBeginningLowerThan(lowerBound, false) && !predicate.test(new SubAutomaton(successor, end, lowerBound, allowPrefix))) {
         return false;
       }
     }

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/SubAutomaton.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/SubAutomaton.java
@@ -21,7 +21,6 @@ package org.sonarsource.analyzer.commons.regex.helpers;
 
 import java.util.Objects;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 import org.sonarsource.analyzer.commons.regex.ast.AutomatonState;
 import org.sonarsource.analyzer.commons.regex.ast.AutomatonState.TransitionType;
 import org.sonarsource.analyzer.commons.regex.ast.IndexRange;
@@ -53,7 +52,8 @@ public class SubAutomaton {
 
   public boolean anySuccessorMatch(Predicate<SubAutomaton> predicate) {
     for (AutomatonState successor : start.successors()) {
-      if (successor.toRegexTree().map(tree -> !excludedRange.contains(tree.getRange())).orElse(true) && predicate.test(new SubAutomaton(successor, end, excludedRange, allowPrefix))) {
+      if (successor.toRegexTree().map(tree -> !excludedRange.contains(tree.getRange())).orElse(true) &&
+          predicate.test(new SubAutomaton(successor, end, excludedRange, allowPrefix))) {
         return true;
       }
     }
@@ -62,7 +62,8 @@ public class SubAutomaton {
 
   public boolean allSuccessorMatch(Predicate<SubAutomaton> predicate) {
     for (AutomatonState successor : start.successors()) {
-      if (successor.toRegexTree().map(tree -> !excludedRange.contains(tree.getRange())).orElse(true) && !predicate.test(new SubAutomaton(successor, end, excludedRange, allowPrefix))) {
+      if (successor.toRegexTree().map(tree -> !excludedRange.contains(tree.getRange())).orElse(true)
+          && !predicate.test(new SubAutomaton(successor, end, excludedRange, allowPrefix))) {
         return false;
       }
     }

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/SupersetAutomataChecker.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/SupersetAutomataChecker.java
@@ -35,19 +35,19 @@ public class SupersetAutomataChecker extends AbstractAutomataChecker {
     SimplifiedRegexCharacterClass characterClass2 = SimplifiedRegexCharacterClass.of(auto2.start);
     return ((characterClass1 != null) && (characterClass2 != null)) ?
       (characterClass1.supersetOf(characterClass2, defaultAnswer) &&
-        auto2.successorsAutomata().allMatch(successor2 ->
-          auto1.successorsAutomata().anyMatch(successor1 ->
+        auto2.allSuccessorMatch(successor2 ->
+          auto1.anySuccessorMatch(successor1 ->
             check(successor1, successor2, true)))) :
       defaultAnswer;
   }
 
   @Override
   protected boolean checkAuto1Successors(SubAutomaton auto1, SubAutomaton auto2, boolean defaultAnswer, boolean hasConsumedInput) {
-    return auto1.successorsAutomata().anyMatch(successor -> check(successor, auto2, hasConsumedInput));
+    return auto1.anySuccessorMatch(successor -> check(successor, auto2, hasConsumedInput));
   }
 
   @Override
   protected boolean checkAuto2Successors(SubAutomaton auto1, SubAutomaton auto2, boolean defaultAnswer, boolean hasConsumedInput) {
-    return auto2.successorsAutomata().allMatch(successor -> check(auto1, successor, hasConsumedInput));
+    return auto2.allSuccessorMatch(successor -> check(auto1, successor, hasConsumedInput));
   }
 }

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/SupersetAutomataChecker.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/helpers/SupersetAutomataChecker.java
@@ -35,18 +35,19 @@ public class SupersetAutomataChecker extends AbstractAutomataChecker {
     SimplifiedRegexCharacterClass characterClass2 = SimplifiedRegexCharacterClass.of(auto2.start);
     return ((characterClass1 != null) && (characterClass2 != null)) ?
       (characterClass1.supersetOf(characterClass2, defaultAnswer) &&
-        auto2.allSuccessorMatch(successor2 -> auto1.anySuccessorMatch(successor1 ->
-          check(successor1, successor2, true)))) :
+        auto2.successorsAutomata().allMatch(successor2 ->
+          auto1.successorsAutomata().anyMatch(successor1 ->
+            check(successor1, successor2, true)))) :
       defaultAnswer;
   }
 
   @Override
   protected boolean checkAuto1Successors(SubAutomaton auto1, SubAutomaton auto2, boolean defaultAnswer, boolean hasConsumedInput) {
-    return auto1.anySuccessorMatch(successor -> check(successor, auto2, hasConsumedInput));
+    return auto1.successorsAutomata().anyMatch(successor -> check(successor, auto2, hasConsumedInput));
   }
 
   @Override
   protected boolean checkAuto2Successors(SubAutomaton auto1, SubAutomaton auto2, boolean defaultAnswer, boolean hasConsumedInput) {
-    return auto2.allSuccessorMatch(successor -> check(auto1, successor, hasConsumedInput));
+    return auto2.successorsAutomata().allMatch(successor -> check(auto1, successor, hasConsumedInput));
   }
 }

--- a/regex-parsing/src/test/java/org/sonarsource/analyzer/commons/regex/helpers/SubAutomatonTest.java
+++ b/regex-parsing/src/test/java/org/sonarsource/analyzer/commons/regex/helpers/SubAutomatonTest.java
@@ -23,6 +23,7 @@ package org.sonarsource.analyzer.commons.regex.helpers;
 import org.junit.jupiter.api.Test;
 import org.sonarsource.analyzer.commons.regex.ast.FinalState;
 import org.sonarsource.analyzer.commons.regex.ast.FlagSet;
+import org.sonarsource.analyzer.commons.regex.ast.IndexRange;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -36,6 +37,7 @@ class SubAutomatonTest {
     SubAutomaton subAutomaton4 = new SubAutomaton(subAutomaton1.start, subAutomaton1.end, false);
     SubAutomaton subAutomaton5 = new SubAutomaton(subAutomaton1.start, subAutomaton2.end, false);
     SubAutomaton subAutomaton6 = new SubAutomaton(subAutomaton2.start, subAutomaton1.end, false);
+    SubAutomaton subAutomaton7 = new SubAutomaton(subAutomaton1.start, subAutomaton2.end, new IndexRange(0, 3), false);
 
     assertThat(subAutomaton1)
       .isNotEqualTo(null)
@@ -44,6 +46,7 @@ class SubAutomatonTest {
       .isNotEqualTo(subAutomaton3)
       .isNotEqualTo(subAutomaton5)
       .isNotEqualTo(subAutomaton6)
+      .isNotEqualTo(subAutomaton7)
       .isEqualTo(subAutomaton4)
       .isEqualTo(subAutomaton1)
       .hasSameHashCodeAs(subAutomaton4);

--- a/regex-parsing/src/test/resources/finders/FailingLookaheadFinder.yml
+++ b/regex-parsing/src/test/resources/finders/FailingLookaheadFinder.yml
@@ -5,10 +5,13 @@
 - '(?!ab)ab' # Noncompliant
 - '(?=a)[^ba]' # Noncompliant
 - '(?!.)ab' # Noncompliant
-- '(?:a(?!bc)|d)+bc' # Noncompliant
+- '(?:a(?!bc))+bc' # Noncompliant
+
+- '(?:a(?!bc)|d)+bc'
+- '(?:a((?!bc)|d)*)+bc'
 - 'a(?!:abc):ab'
 - '(?:-(?:one|[0-9]+([a-z](?=[^a-z]|$)|st|nd|rd|th)?))*'
-
+- '(..(?=ab))*'
 - '(?=a)a'
 - '(?=a)..'
 - '(?=a)ab'

--- a/regex-parsing/src/test/resources/finders/FailingLookaheadFinder.yml
+++ b/regex-parsing/src/test/resources/finders/FailingLookaheadFinder.yml
@@ -7,6 +7,7 @@
 - '(?!.)ab' # Noncompliant
 - '(?:a(?!bc)|d)+bc' # Noncompliant
 - 'a(?!:abc):ab'
+- '(?:-(?:one|[0-9]+([a-z](?=[^a-z]|$)|st|nd|rd|th)?))*'
 
 - '(?=a)a'
 - '(?=a)..'

--- a/regex-parsing/src/test/resources/finders/FailingLookaheadFinder.yml
+++ b/regex-parsing/src/test/resources/finders/FailingLookaheadFinder.yml
@@ -6,6 +6,7 @@
 - '(?=a)[^ba]' # Noncompliant
 - '(?!.)ab' # Noncompliant
 - '(?:a(?!bc))+bc' # Noncompliant
+- '(?:(x|y)(?!bc))+bc' # Noncompliant
 
 - '(?:a(?!bc)|d)+bc'
 - '(?:a((?!bc)|d)*)+bc'

--- a/regex-parsing/src/test/resources/finders/FailingLookaheadFinder.yml
+++ b/regex-parsing/src/test/resources/finders/FailingLookaheadFinder.yml
@@ -5,6 +5,7 @@
 - '(?!ab)ab' # Noncompliant
 - '(?=a)[^ba]' # Noncompliant
 - '(?!.)ab' # Noncompliant
+- '(?:a(?!bc)|d)+bc' # Noncompliant
 - 'a(?!:abc):ab'
 
 - '(?=a)a'

--- a/regex-parsing/src/test/resources/finders/PossessiveQuantifierContinuationFinder.yml
+++ b/regex-parsing/src/test/resources/finders/PossessiveQuantifierContinuationFinder.yml
@@ -8,6 +8,9 @@
 - '.*+\w' # Noncompliant
 - '.*+\w+' # Noncompliant
 - '(a|b|c)*+(a|b)' # Noncompliant
+- '(bx++)+x' # Noncompliant
+- '(b(?:xy|c)++)+xy+d' # Noncompliant
+- '(((?:xyz)++x)+y)+z' # Noncompliant
 
 - 'a+abc'
 - 'a+?abc'
@@ -15,5 +18,4 @@
 - 'aa++bc'
 - '\d*+(?<=[02468])'
 - '(:[0-9])?+(:[0-9])?+'
-- '(bx++)+x' # FN because limitation of the algorithm when there's infinite loop
 - '(?(1)(.*)|())'


### PR DESCRIPTION
Fix #256 

This change adds a way to exclude nodes of an Automaton from being transitioned to, based on their `IndexRange`. `BranchTrackingVisitor` keeps track of the last repetition/disjunction visited, which lets us exclude the correct nodes.

~~Performance-wise, it decreases the time needed for the corresponding rules (S5994 and S6002). However, rule S5855 also uses intersection but does not need the added feature, and takes a small performance hit.~~
Fixed by https://github.com/SonarSource/sonar-analyzer-commons/pull/257/commits/d895d2b2e449009b30de61598e8ccd89d8850a5a