### PR TITLE
Avoid calling 'scan' two times in code recognizers

### DIFF
--- a/recognizers/src/main/java/org/sonarsource/analyzer/commons/recognizers/Detector.java
+++ b/recognizers/src/main/java/org/sonarsource/analyzer/commons/recognizers/Detector.java
@@ -37,6 +37,6 @@ public abstract class Detector {
     if (matchers == 0) {
       return 0;
     }
-    return 1 - Math.pow(1 - probability, scan(line));
+    return 1 - Math.pow(1 - probability, matchers);
   }
 }


### PR DESCRIPTION
Should improve the performance of the following detectors:
* `CamelCaseDetector`
* `ContainsDetector`
* `EndWithDetector`
* `KeywordsDetector`
* `RegexDetector`