### PR TITLE
Add `keySet` method on `PMap` and `stream` method on `PSet` and `PStack`

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/collections/AVLTree.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/collections/AVLTree.java
@@ -133,6 +133,11 @@ abstract class AVLTree<K, V> implements PMap<K, V>, PSet<K> {
     }
   }
 
+  @Override
+  public PSet<K> keySet() {
+    return this;
+  }
+
   // Used by IntelliJ renderer, to ease debugging
   @VisibleForTesting
   Object[] toArray() {

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PMap.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PMap.java
@@ -20,7 +20,6 @@
 package org.sonarsource.analyzer.commons.collections;
 
 import java.util.Map;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import java.util.function.BiConsumer;
 

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PMap.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PMap.java
@@ -20,6 +20,7 @@
 package org.sonarsource.analyzer.commons.collections;
 
 import java.util.Map;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import java.util.function.BiConsumer;
 
@@ -68,4 +69,9 @@ public interface PMap<K, V> {
   String toString();
 
   Iterable<Map.Entry<K, V>> entries();
+
+  /**
+   * @return a set view of the keys contained in the map.
+   */
+  PSet<K> keySet();
 }

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PSet.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PSet.java
@@ -19,6 +19,9 @@
  */
 package org.sonarsource.analyzer.commons.collections;
 
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
 /**
  * Persistent (functional) Set.
  *
@@ -56,4 +59,10 @@ public interface PSet<E> extends Iterable<E> {
   @Override
   String toString();
 
+  /**
+   * @return stream of the set's elements
+   */
+  default Stream<E> stream() {
+    return StreamSupport.stream(this.spliterator(), false);
+  }
 }

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PStack.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PStack.java
@@ -20,6 +20,8 @@
 package org.sonarsource.analyzer.commons.collections;
 
 import java.util.function.Predicate;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Persistent (functional) Stack.
@@ -77,4 +79,10 @@ public interface PStack<E> extends Iterable<E> {
   @Override
   String toString();
 
+  /**
+   * @return stream of the stack's elements, starting at the top of the stack
+   */
+  default Stream<E> stream() {
+    return StreamSupport.stream(this.spliterator(), false);
+  }
 }

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/collections/AVLTreeTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/collections/AVLTreeTest.java
@@ -471,7 +471,7 @@ public class AVLTreeTest {
     PMap<String, Integer> map = PCollections.emptyMap();
     map = map.put("A", 3).put("B", 4);
     PSet<String> set = map.keySet();
-    assertThat(set).contains("A", "B");
+    assertThat(set).containsExactlyInAnyOrder("B", "A");
   }
 
   @Test
@@ -484,6 +484,19 @@ public class AVLTreeTest {
     PSet<Integer> set = PCollections.emptySet();
     set = set.add(1).add(2).add(3);
     Stream<Integer> stream = set.stream();
-    assertThat(stream).contains(1, 2, 3);
+    assertThat(stream).containsExactlyInAnyOrder(1, 2, 3);
+  }
+
+  @Test
+  public void test_empty_stack_stream() {
+    assertThat(PCollections.emptyStack().stream()).isEmpty();
+  }
+
+  @Test
+  public void test_stack_stream() {
+    PStack<Integer> stack = PCollections.emptyStack();
+    stack = stack.push(1).push(2).push(3);
+    Stream<Integer> stream = stack.stream();
+    assertThat(stream).containsExactly(3, 2, 1);
   }
 }

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/collections/AVLTreeTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/collections/AVLTreeTest.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -458,5 +459,31 @@ public class AVLTreeTest {
       iterator.next();
       fail("next() should throw NoSuchElementException on empty stack");
     }  catch (NoSuchElementException exception) {}
+  }
+
+  @Test
+  public void test_empty_keyset() {
+    assertThat(PCollections.emptyMap().keySet()).isEmpty();
+  }
+
+  @Test
+  public void test_keyset() {
+    PMap<String, Integer> map = PCollections.emptyMap();
+    map = map.put("A", 3).put("B", 4);
+    PSet<String> set = map.keySet();
+    assertThat(set).contains("A", "B");
+  }
+
+  @Test
+  public void test_empty_set_stream() {
+    assertThat(PCollections.emptySet().stream()).isEmpty();
+  }
+
+  @Test
+  public void test_set_stream() {
+    PSet<Integer> set = PCollections.emptySet();
+    set = set.add(1).add(2).add(3);
+    Stream<Integer> stream = set.stream();
+    assertThat(stream).contains(1, 2, 3);
   }
 }


### PR DESCRIPTION
- Add a method to return the set of keys in a `PMap`
- Add a method to return a stream of the elements in a `PSet`
- Add a method to return a stream of the elements in a `PStack`, starting at the top of the stack