### PR TITLE
BUILD-3877 Migrate from GCP promote function

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -81,9 +81,7 @@ promote_task:
     cpu: 0.5
     memory: 500M
   env:
-    #promotion cloud function
-    GCF_ACCESS_TOKEN: VAULT[development/kv/data/promote data.token]
-    PROMOTE_URL: VAULT[development/kv/data/promote data.url]
+    ARTIFACTORY_PROMOTE_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]
     GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promotion token]
     #artifacts that will have downloadable links in burgr
     ARTIFACTS: "org.sonarsource.analyzer-commons:sonar-analyzer-commons:jar" 


### PR DESCRIPTION
Provide `ARTIFACTORY_PROMOTE_ACCESS_TOKEN` to migrate from the deprecated GCP promote function.