### PR TITLE
ACOMMONS-15: Add convenience factory methods for small collections

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PCollections.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PCollections.java
@@ -24,15 +24,35 @@ public final class PCollections {
   private PCollections() {
   }
 
+  /**
+   * Returns a persistent set containing zero elements.
+   *
+   * @param <E> the {@code PSet}'s element type
+   * @return an empty {@code PSet}
+   */
   public static <E> PSet<E> emptySet() {
     return AVLTree.create();
   }
 
+  /**
+   * Returns a persistent map containing zero mappings.
+   *
+   * @param <E> the {@code PMap}'s key type
+   * @param <V> the {@code PMap}'s value type
+   * @return an empty {@code PMap}
+   */
   public static <E, V> PMap<E, V> emptyMap() {
     return AVLTree.create();
   }
 
+  /**
+   * Returns a persistent stack containing zero elements.
+   *
+   * @param <E> the {@code PStack}'s element type
+   * @return an empty {@code PStack}
+   */
+  @SuppressWarnings("unchecked")
   public static <E> PStack<E> emptyStack() {
-    return SinglyLinkedList.EMPTY;
+    return (PStack<E>) SinglyLinkedList.EMPTY;
   }
 }

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PCollections.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PCollections.java
@@ -53,6 +53,6 @@ public final class PCollections {
    */
   @SuppressWarnings("unchecked")
   public static <E> PStack<E> emptyStack() {
-    return (PStack<E>) SinglyLinkedList.EMPTY;
+    return SinglyLinkedList.EMPTY;
   }
 }

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PMap.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PMap.java
@@ -73,4 +73,290 @@ public interface PMap<K, V> {
    * @return a set view of the keys contained in the map.
    */
   PSet<K> keySet();
+
+  /**
+   * Returns a persistent map containing zero mappings.
+   *
+   * @param <K> the {@code PMap}'s key type
+   * @param <V> the {@code PMap}'s value type
+   * @return an empty {@code PMap}
+   */
+  static <K, V> PMap<K, V> of() {
+    return PCollections.emptyMap();
+  }
+
+  /**
+   * Returns a persistent map containing a single mapping.
+   *
+   * @param <K> the {@code PMap}'s key type
+   * @param <V> the {@code PMap}'s value type
+   * @param k1 the mapping's key
+   * @param v1 the mapping's value
+   * @return a {@code PMap} containing the specified mapping
+   */
+  static <K, V> PMap<K, V> of(K k1, V v1) {
+    return PCollections.<K, V>emptyMap()
+      .put(k1, v1);
+  }
+
+  /**
+   * Returns a persistent map containing two mappings.
+   *
+   * @param <K> the {@code PMap}'s key type
+   * @param <V> the {@code PMap}'s value type
+   * @param k1 the first mapping's key
+   * @param v1 the first mapping's value
+   * @param k2 the second mapping's key
+   * @param v2 the second mapping's value
+   * @return a {@code PMap} containing the specified mappings
+   */
+  static <K, V> PMap<K, V> of(K k1, V v1, K k2, V v2) {
+    return PCollections.<K, V>emptyMap()
+      .put(k1, v1)
+      .put(k2, v2);
+  }
+
+  /**
+   * Returns a persistent map containing three mappings.
+   *
+   * @param <K> the {@code PMap}'s key type
+   * @param <V> the {@code PMap}'s value type
+   * @param k1 the first mapping's key
+   * @param v1 the first mapping's value
+   * @param k2 the second mapping's key
+   * @param v2 the second mapping's value
+   * @param k3 the third mapping's key
+   * @param v3 the third mapping's value
+   * @return a {@code PMap} containing the specified mappings
+   */
+  static <K, V> PMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3) {
+    return PCollections.<K, V>emptyMap()
+      .put(k1, v1)
+      .put(k2, v2)
+      .put(k3, v3);
+  }
+
+  /**
+   * Returns a persistent map containing four mappings.
+   *
+   * @param <K> the {@code PMap}'s key type
+   * @param <V> the {@code PMap}'s value type
+   * @param k1 the first mapping's key
+   * @param v1 the first mapping's value
+   * @param k2 the second mapping's key
+   * @param v2 the second mapping's value
+   * @param k3 the third mapping's key
+   * @param v3 the third mapping's value
+   * @param k4 the fourth mapping's key
+   * @param v4 the fourth mapping's value
+   * @return a {@code PMap} containing the specified mappings
+   */
+  static <K, V> PMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
+    return PCollections.<K, V>emptyMap()
+      .put(k1, v1)
+      .put(k2, v2)
+      .put(k3, v3)
+      .put(k4, v4);
+  }
+
+  /**
+   * Returns a persistent map containing five mappings.
+   *
+   * @param <K> the {@code PMap}'s key type
+   * @param <V> the {@code PMap}'s value type
+   * @param k1 the first mapping's key
+   * @param v1 the first mapping's value
+   * @param k2 the second mapping's key
+   * @param v2 the second mapping's value
+   * @param k3 the third mapping's key
+   * @param v3 the third mapping's value
+   * @param k4 the fourth mapping's key
+   * @param v4 the fourth mapping's value
+   * @param k5 the fifth mapping's key
+   * @param v5 the fifth mapping's value
+   * @return a {@code PMap} containing the specified mappings
+   */
+  static <K, V> PMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
+    return PCollections.<K, V>emptyMap()
+      .put(k1, v1)
+      .put(k2, v2)
+      .put(k3, v3)
+      .put(k4, v4)
+      .put(k5, v5);
+  }
+
+  /**
+   * Returns a persistent map containing six mappings.
+   *
+   * @param <K> the {@code PMap}'s key type
+   * @param <V> the {@code PMap}'s value type
+   * @param k1 the first mapping's key
+   * @param v1 the first mapping's value
+   * @param k2 the second mapping's key
+   * @param v2 the second mapping's value
+   * @param k3 the third mapping's key
+   * @param v3 the third mapping's value
+   * @param k4 the fourth mapping's key
+   * @param v4 the fourth mapping's value
+   * @param k5 the fifth mapping's key
+   * @param v5 the fifth mapping's value
+   * @param k6 the sixth mapping's key
+   * @param v6 the sixth mapping's value
+   * @return a {@code PMap} containing the specified mappings
+   */
+  static <K, V> PMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6) {
+    return PCollections.<K, V>emptyMap()
+      .put(k1, v1)
+      .put(k2, v2)
+      .put(k3, v3)
+      .put(k4, v4)
+      .put(k5, v5)
+      .put(k6, v6);
+  }
+
+  /**
+   * Returns a persistent map containing seven mappings.
+   *
+   * @param <K> the {@code PMap}'s key type
+   * @param <V> the {@code PMap}'s value type
+   * @param k1 the first mapping's key
+   * @param v1 the first mapping's value
+   * @param k2 the second mapping's key
+   * @param v2 the second mapping's value
+   * @param k3 the third mapping's key
+   * @param v3 the third mapping's value
+   * @param k4 the fourth mapping's key
+   * @param v4 the fourth mapping's value
+   * @param k5 the fifth mapping's key
+   * @param v5 the fifth mapping's value
+   * @param k6 the sixth mapping's key
+   * @param v6 the sixth mapping's value
+   * @param k7 the seventh mapping's key
+   * @param v7 the seventh mapping's value
+   * @return a {@code PMap} containing the specified mappings
+   */
+  static <K, V> PMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7) {
+    return PCollections.<K, V>emptyMap()
+      .put(k1, v1)
+      .put(k2, v2)
+      .put(k3, v3)
+      .put(k4, v4)
+      .put(k5, v5)
+      .put(k6, v6)
+      .put(k7, v7);
+  }
+
+  /**
+   * Returns a persistent map containing eight mappings.
+   *
+   * @param <K> the {@code PMap}'s key type
+   * @param <V> the {@code PMap}'s value type
+   * @param k1 the first mapping's key
+   * @param v1 the first mapping's value
+   * @param k2 the second mapping's key
+   * @param v2 the second mapping's value
+   * @param k3 the third mapping's key
+   * @param v3 the third mapping's value
+   * @param k4 the fourth mapping's key
+   * @param v4 the fourth mapping's value
+   * @param k5 the fifth mapping's key
+   * @param v5 the fifth mapping's value
+   * @param k6 the sixth mapping's key
+   * @param v6 the sixth mapping's value
+   * @param k7 the seventh mapping's key
+   * @param v7 the seventh mapping's value
+   * @param k8 the eighth mapping's key
+   * @param v8 the eighth mapping's value
+   * @return a {@code PMap} containing the specified mappings
+   */
+  static <K, V> PMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8) {
+    return PCollections.<K, V>emptyMap()
+      .put(k1, v1)
+      .put(k2, v2)
+      .put(k3, v3)
+      .put(k4, v4)
+      .put(k5, v5)
+      .put(k6, v6)
+      .put(k7, v7)
+      .put(k8, v8);
+  }
+
+  /**
+   * Returns a persistent map containing nine mappings.
+   *
+   * @param <K> the {@code PMap}'s key type
+   * @param <V> the {@code PMap}'s value type
+   * @param k1 the first mapping's key
+   * @param v1 the first mapping's value
+   * @param k2 the second mapping's key
+   * @param v2 the second mapping's value
+   * @param k3 the third mapping's key
+   * @param v3 the third mapping's value
+   * @param k4 the fourth mapping's key
+   * @param v4 the fourth mapping's value
+   * @param k5 the fifth mapping's key
+   * @param v5 the fifth mapping's value
+   * @param k6 the sixth mapping's key
+   * @param v6 the sixth mapping's value
+   * @param k7 the seventh mapping's key
+   * @param v7 the seventh mapping's value
+   * @param k8 the eighth mapping's key
+   * @param v8 the eighth mapping's value
+   * @param k9 the ninth mapping's key
+   * @param v9 the ninth mapping's value
+   * @return a {@code PMap} containing the specified mappings
+   */
+  static <K, V> PMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9) {
+    return PCollections.<K, V>emptyMap()
+      .put(k1, v1)
+      .put(k2, v2)
+      .put(k3, v3)
+      .put(k4, v4)
+      .put(k5, v5)
+      .put(k6, v6)
+      .put(k7, v7)
+      .put(k8, v8)
+      .put(k9, v9);
+  }
+
+  /**
+   * Returns a persistent map containing ten mappings.
+   *
+   * @param <K> the {@code PMap}'s key type
+   * @param <V> the {@code PMap}'s value type
+   * @param k1 the first mapping's key
+   * @param v1 the first mapping's value
+   * @param k2 the second mapping's key
+   * @param v2 the second mapping's value
+   * @param k3 the third mapping's key
+   * @param v3 the third mapping's value
+   * @param k4 the fourth mapping's key
+   * @param v4 the fourth mapping's value
+   * @param k5 the fifth mapping's key
+   * @param v5 the fifth mapping's value
+   * @param k6 the sixth mapping's key
+   * @param v6 the sixth mapping's value
+   * @param k7 the seventh mapping's key
+   * @param v7 the seventh mapping's value
+   * @param k8 the eighth mapping's key
+   * @param v8 the eighth mapping's value
+   * @param k9 the ninth mapping's key
+   * @param v9 the ninth mapping's value
+   * @param k10 the tenth mapping's key
+   * @param v10 the tenth mapping's value
+   * @return a {@code PMap} containing the specified mappings
+   */
+  static <K, V> PMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9, K k10, V v10) {
+    return PCollections.<K, V>emptyMap()
+      .put(k1, v1)
+      .put(k2, v2)
+      .put(k3, v3)
+      .put(k4, v4)
+      .put(k5, v5)
+      .put(k6, v6)
+      .put(k7, v7)
+      .put(k8, v8)
+      .put(k9, v9)
+      .put(k10, v10);
+  }
 }

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PSet.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PSet.java
@@ -65,4 +65,224 @@ public interface PSet<E> extends Iterable<E> {
   default Stream<E> stream() {
     return StreamSupport.stream(this.spliterator(), false);
   }
+
+  /**
+   * Returns a persistent set containing zero elements.
+   *
+   * @param <E> the {@code PSet}'s element type
+   * @return an empty {@code PSet}
+   */
+  static <E> PSet<E> of() {
+    return PCollections.emptySet();
+  }
+
+  /**
+   * Returns a persistent set containing one element.
+   *
+   * @param <E> the {@code PSet}'s element type
+   * @param e1 the single element
+   * @return a {@code PSet} containing the specified element
+   */
+  static <E> PSet<E> of(E e1) {
+    return PCollections.<E>emptySet()
+      .add(e1);
+  }
+
+  /**
+   * Returns a persistent set containing two elements.
+   *
+   * @param <E> the {@code PSet}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @return a {@code PSet} containing the specified elements
+   */
+  static <E> PSet<E> of(E e1, E e2) {
+    return PCollections.<E>emptySet()
+      .add(e1)
+      .add(e2);
+  }
+
+  /**
+   * Returns a persistent set containing three elements.
+   *
+   * @param <E> the {@code PSet}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @return a {@code PSet} containing the specified elements
+   */
+  static <E> PSet<E> of(E e1, E e2, E e3) {
+    return PCollections.<E>emptySet()
+      .add(e1)
+      .add(e2)
+      .add(e3);
+  }
+
+  /**
+   * Returns a persistent set containing four elements.
+   *
+   * @param <E> the {@code PSet}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @param e4 the fourth element
+   * @return a {@code PSet} containing the specified elements
+   */
+  static <E> PSet<E> of(E e1, E e2, E e3, E e4) {
+    return PCollections.<E>emptySet()
+      .add(e1)
+      .add(e2)
+      .add(e3)
+      .add(e4);
+  }
+
+  /**
+   * Returns a persistent set containing five elements.
+   *
+   * @param <E> the {@code PSet}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @param e4 the fourth element
+   * @param e5 the fifth element
+   * @return a {@code PSet} containing the specified elements
+   */
+  static <E> PSet<E> of(E e1, E e2, E e3, E e4, E e5) {
+    return PCollections.<E>emptySet()
+      .add(e1)
+      .add(e2)
+      .add(e3)
+      .add(e4)
+      .add(e5);
+  }
+
+  /**
+   * Returns a persistent set containing six elements.
+   *
+   * @param <E> the {@code PSet}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @param e4 the fourth element
+   * @param e5 the fifth element
+   * @param e6 the sixth element
+   * @return a {@code PSet} containing the specified elements
+   */
+  static <E> PSet<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
+    return PCollections.<E>emptySet()
+      .add(e1)
+      .add(e2)
+      .add(e3)
+      .add(e4)
+      .add(e5)
+      .add(e6);
+  }
+
+  /**
+   * Returns a persistent set containing seven elements.
+   *
+   * @param <E> the {@code PSet}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @param e4 the fourth element
+   * @param e5 the fifth element
+   * @param e6 the sixth element
+   * @param e7 the seventh element
+   * @return a {@code PSet} containing the specified elements
+   */
+  static <E> PSet<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
+    return PCollections.<E>emptySet()
+      .add(e1)
+      .add(e2)
+      .add(e3)
+      .add(e4)
+      .add(e5)
+      .add(e6)
+      .add(e7);
+  }
+
+  /**
+   * Returns a persistent set containing eight elements.
+   *
+   * @param <E> the {@code PSet}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @param e4 the fourth element
+   * @param e5 the fifth element
+   * @param e6 the sixth element
+   * @param e7 the seventh element
+   * @param e8 the eighth element
+   * @return a {@code PSet} containing the specified elements
+   */
+  static <E> PSet<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
+    return PCollections.<E>emptySet()
+      .add(e1)
+      .add(e2)
+      .add(e3)
+      .add(e4)
+      .add(e5)
+      .add(e6)
+      .add(e7)
+      .add(e8);
+  }
+
+  /**
+   * Returns a persistent set containing nine elements.
+   *
+   * @param <E> the {@code PSet}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @param e4 the fourth element
+   * @param e5 the fifth element
+   * @param e6 the sixth element
+   * @param e7 the seventh element
+   * @param e8 the eighth element
+   * @param e9 the ninth element
+   * @return a {@code PSet} containing the specified elements
+   */
+  static <E> PSet<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
+    return PCollections.<E>emptySet()
+      .add(e1)
+      .add(e2)
+      .add(e3)
+      .add(e4)
+      .add(e5)
+      .add(e6)
+      .add(e7)
+      .add(e8)
+      .add(e9);
+  }
+
+  /**
+   * Returns a persistent set containing ten elements.
+   *
+   * @param <E> the {@code PSet}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @param e4 the fourth element
+   * @param e5 the fifth element
+   * @param e6 the sixth element
+   * @param e7 the seventh element
+   * @param e8 the eighth element
+   * @param e9 the ninth element
+   * @param e10 the tenth element
+   * @return a {@code PSet} containing the specified elements
+   */
+  static <E> PSet<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
+    return PCollections.<E>emptySet()
+      .add(e1)
+      .add(e2)
+      .add(e3)
+      .add(e4)
+      .add(e5)
+      .add(e6)
+      .add(e7)
+      .add(e8)
+      .add(e9)
+      .add(e10);
+  }
 }

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PStack.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/collections/PStack.java
@@ -85,4 +85,224 @@ public interface PStack<E> extends Iterable<E> {
   default Stream<E> stream() {
     return StreamSupport.stream(this.spliterator(), false);
   }
+
+  /**
+   * Returns a persistent stack containing zero elements.
+   *
+   * @param <E> the {@code PStack}'s element type
+   * @return an empty {@code PStack}
+   */
+  static <E> PStack<E> of() {
+    return PCollections.emptyStack();
+  }
+
+  /**
+   * Returns a persistent stack containing one element.
+   *
+   * @param <E> the {@code PStack}'s element type
+   * @param e1 the single element
+   * @return a {@code PStack} containing the specified element
+   */
+  static <E> PStack<E> of(E e1) {
+    return PCollections.<E>emptyStack()
+      .push(e1);
+  }
+
+  /**
+   * Returns a persistent stack containing two elements, pushed left to right.
+   *
+   * @param <E> the {@code PStack}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @return a {@code PStack} containing the specified elements
+   */
+  static <E> PStack<E> of(E e1, E e2) {
+    return PCollections.<E>emptyStack()
+      .push(e1)
+      .push(e2);
+  }
+
+  /**
+   * Returns a persistent stack containing three elements, pushed left to right.
+   *
+   * @param <E> the {@code PStack}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @return a {@code PStack} containing the specified elements
+   */
+  static <E> PStack<E> of(E e1, E e2, E e3) {
+    return PCollections.<E>emptyStack()
+      .push(e1)
+      .push(e2)
+      .push(e3);
+  }
+
+  /**
+   * Returns a persistent stack containing four elements, pushed left to right.
+   *
+   * @param <E> the {@code PStack}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @param e4 the fourth element
+   * @return a {@code PStack} containing the specified elements
+   */
+  static <E> PStack<E> of(E e1, E e2, E e3, E e4) {
+    return PCollections.<E>emptyStack()
+      .push(e1)
+      .push(e2)
+      .push(e3)
+      .push(e4);
+  }
+
+  /**
+   * Returns a persistent stack containing five elements, pushed left to right.
+   *
+   * @param <E> the {@code PStack}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @param e4 the fourth element
+   * @param e5 the fifth element
+   * @return a {@code PStack} containing the specified elements
+   */
+  static <E> PStack<E> of(E e1, E e2, E e3, E e4, E e5) {
+    return PCollections.<E>emptyStack()
+      .push(e1)
+      .push(e2)
+      .push(e3)
+      .push(e4)
+      .push(e5);
+  }
+
+  /**
+   * Returns a persistent stack containing six elements, pushed left to right.
+   *
+   * @param <E> the {@code PStack}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @param e4 the fourth element
+   * @param e5 the fifth element
+   * @param e6 the sixth element
+   * @return a {@code PStack} containing the specified elements
+   */
+  static <E> PStack<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
+    return PCollections.<E>emptyStack()
+      .push(e1)
+      .push(e2)
+      .push(e3)
+      .push(e4)
+      .push(e5)
+      .push(e6);
+  }
+
+  /**
+   * Returns a persistent stack containing seven elements, pushed left to right.
+   *
+   * @param <E> the {@code PStack}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @param e4 the fourth element
+   * @param e5 the fifth element
+   * @param e6 the sixth element
+   * @param e7 the seventh element
+   * @return a {@code PStack} containing the specified elements
+   */
+  static <E> PStack<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
+    return PCollections.<E>emptyStack()
+      .push(e1)
+      .push(e2)
+      .push(e3)
+      .push(e4)
+      .push(e5)
+      .push(e6)
+      .push(e7);
+  }
+
+  /**
+   * Returns a persistent stack containing eight elements, pushed left to right.
+   *
+   * @param <E> the {@code PStack}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @param e4 the fourth element
+   * @param e5 the fifth element
+   * @param e6 the sixth element
+   * @param e7 the seventh element
+   * @param e8 the eighth element
+   * @return a {@code PStack} containing the specified elements
+   */
+  static <E> PStack<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
+    return PCollections.<E>emptyStack()
+      .push(e1)
+      .push(e2)
+      .push(e3)
+      .push(e4)
+      .push(e5)
+      .push(e6)
+      .push(e7)
+      .push(e8);
+  }
+
+  /**
+   * Returns a persistent stack containing nine elements, pushed left to right.
+   *
+   * @param <E> the {@code PStack}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @param e4 the fourth element
+   * @param e5 the fifth element
+   * @param e6 the sixth element
+   * @param e7 the seventh element
+   * @param e8 the eighth element
+   * @param e9 the ninth element
+   * @return a {@code PStack} containing the specified elements
+   */
+  static <E> PStack<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
+    return PCollections.<E>emptyStack()
+      .push(e1)
+      .push(e2)
+      .push(e3)
+      .push(e4)
+      .push(e5)
+      .push(e6)
+      .push(e7)
+      .push(e8)
+      .push(e9);
+  }
+
+  /**
+   * Returns a persistent stack containing ten elements, pushed left to right.
+   *
+   * @param <E> the {@code PStack}'s element type
+   * @param e1 the first element
+   * @param e2 the second element
+   * @param e3 the third element
+   * @param e4 the fourth element
+   * @param e5 the fifth element
+   * @param e6 the sixth element
+   * @param e7 the seventh element
+   * @param e8 the eighth element
+   * @param e9 the ninth element
+   * @param e10 the tenth element
+   * @return a {@code PStack} containing the specified elements
+   */
+  static <E> PStack<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
+    return PCollections.<E>emptyStack()
+      .push(e1)
+      .push(e2)
+      .push(e3)
+      .push(e4)
+      .push(e5)
+      .push(e6)
+      .push(e7)
+      .push(e8)
+      .push(e9)
+      .push(e10);
+  }
 }

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/collections/PMapTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/collections/PMapTest.java
@@ -1,0 +1,243 @@
+/*
+ * SonarSource Analyzers Commons
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.analyzer.commons.collections;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class PMapTest {
+  @Test
+  public void lastDupeWins() {
+    var map = PMap.of(
+      "banana", 1,
+      "apple", 2,
+      "banana", 42
+    );
+
+    assertThat(getSize(map.entries())).isEqualTo(2);
+    assertThat(map.get("banana")).isEqualTo(42);
+  }
+
+  @Test
+  public void of0() {
+    assertThat(PMap.of()).isSameAs(PCollections.emptyMap());
+  }
+
+  @Test
+  public void of1() {
+    var map = PMap.of(
+      "partridge in a pear tree", 1
+    );
+
+    assertThat(getSize(map.entries())).isEqualTo(1);
+    assertThat(map.get("partridge in a pear tree")).isEqualTo(1);
+  }
+
+  @Test
+  public void of2() {
+    var map = PMap.of(
+      "partridge in a pear tree", 1,
+      "turtle dove", 2
+    );
+
+    assertThat(getSize(map.entries())).isEqualTo(2);
+    assertThat(map.get("partridge in a pear tree")).isEqualTo(1);
+    assertThat(map.get("turtle dove")).isEqualTo(2);
+  }
+
+  @Test
+  public void of3() {
+    var map = PMap.of(
+      "partridge in a pear tree", 1,
+      "turtle dove", 2,
+      "French hen", 3
+    );
+
+    assertThat(getSize(map.entries())).isEqualTo(3);
+    assertThat(map.get("partridge in a pear tree")).isEqualTo(1);
+    assertThat(map.get("turtle dove")).isEqualTo(2);
+    assertThat(map.get("French hen")).isEqualTo(3);
+  }
+
+  @Test
+  public void of4() {
+    var map = PMap.of(
+      "partridge in a pear tree", 1,
+      "turtle dove", 2,
+      "French hen", 3,
+      "calling bird", 4
+    );
+
+    assertThat(getSize(map.entries())).isEqualTo(4);
+    assertThat(map.get("partridge in a pear tree")).isEqualTo(1);
+    assertThat(map.get("turtle dove")).isEqualTo(2);
+    assertThat(map.get("French hen")).isEqualTo(3);
+    assertThat(map.get("calling bird")).isEqualTo(4);
+  }
+
+  @Test
+  public void of5() {
+    var map = PMap.of(
+      "partridge in a pear tree", 1,
+      "turtle dove", 2,
+      "French hen", 3,
+      "calling bird", 4,
+      "gold ring", 5
+    );
+
+    assertThat(getSize(map.entries())).isEqualTo(5);
+    assertThat(map.get("partridge in a pear tree")).isEqualTo(1);
+    assertThat(map.get("turtle dove")).isEqualTo(2);
+    assertThat(map.get("French hen")).isEqualTo(3);
+    assertThat(map.get("calling bird")).isEqualTo(4);
+    assertThat(map.get("gold ring")).isEqualTo(5);
+  }
+
+  @Test
+  public void of6() {
+    var map = PMap.of(
+      "partridge in a pear tree", 1,
+      "turtle dove", 2,
+      "French hen", 3,
+      "calling bird", 4,
+      "gold ring", 5,
+      "geese a-laying", 6
+    );
+
+    assertThat(getSize(map.entries())).isEqualTo(6);
+    assertThat(map.get("partridge in a pear tree")).isEqualTo(1);
+    assertThat(map.get("turtle dove")).isEqualTo(2);
+    assertThat(map.get("French hen")).isEqualTo(3);
+    assertThat(map.get("calling bird")).isEqualTo(4);
+    assertThat(map.get("gold ring")).isEqualTo(5);
+    assertThat(map.get("geese a-laying")).isEqualTo(6);
+  }
+
+  @Test
+  public void of7() {
+    var map = PMap.of(
+      "partridge in a pear tree", 1,
+      "turtle dove", 2,
+      "French hen", 3,
+      "calling bird", 4,
+      "gold ring", 5,
+      "goose a-laying", 6,
+      "swan a-swimming", 7
+    );
+
+    assertThat(getSize(map.entries())).isEqualTo(7);
+    assertThat(map.get("partridge in a pear tree")).isEqualTo(1);
+    assertThat(map.get("turtle dove")).isEqualTo(2);
+    assertThat(map.get("French hen")).isEqualTo(3);
+    assertThat(map.get("calling bird")).isEqualTo(4);
+    assertThat(map.get("gold ring")).isEqualTo(5);
+    assertThat(map.get("goose a-laying")).isEqualTo(6);
+    assertThat(map.get("swan a-swimming")).isEqualTo(7);
+  }
+
+  @Test
+  public void of8() {
+    var map = PMap.of(
+      "partridge in a pear tree", 1,
+      "turtle dove", 2,
+      "French hen", 3,
+      "calling bird", 4,
+      "gold ring", 5,
+      "goose a-laying", 6,
+      "swan a-swimming", 7,
+      "maid a-milking", 8
+    );
+
+    assertThat(getSize(map.entries())).isEqualTo(8);
+    assertThat(map.get("partridge in a pear tree")).isEqualTo(1);
+    assertThat(map.get("turtle dove")).isEqualTo(2);
+    assertThat(map.get("French hen")).isEqualTo(3);
+    assertThat(map.get("calling bird")).isEqualTo(4);
+    assertThat(map.get("gold ring")).isEqualTo(5);
+    assertThat(map.get("goose a-laying")).isEqualTo(6);
+    assertThat(map.get("swan a-swimming")).isEqualTo(7);
+    assertThat(map.get("maid a-milking")).isEqualTo(8);
+  }
+
+  @Test
+  public void of9() {
+    var map = PMap.of(
+      "partridge in a pear tree", 1,
+      "turtle dove", 2,
+      "French hen", 3,
+      "calling bird", 4,
+      "gold ring", 5,
+      "goose a-laying", 6,
+      "swan a-swimming", 7,
+      "maid a-milking", 8,
+      "lady dancing", 9
+    );
+
+    assertThat(getSize(map.entries())).isEqualTo(9);
+    assertThat(map.get("partridge in a pear tree")).isEqualTo(1);
+    assertThat(map.get("turtle dove")).isEqualTo(2);
+    assertThat(map.get("French hen")).isEqualTo(3);
+    assertThat(map.get("calling bird")).isEqualTo(4);
+    assertThat(map.get("gold ring")).isEqualTo(5);
+    assertThat(map.get("goose a-laying")).isEqualTo(6);
+    assertThat(map.get("swan a-swimming")).isEqualTo(7);
+    assertThat(map.get("maid a-milking")).isEqualTo(8);
+    assertThat(map.get("lady dancing")).isEqualTo(9);
+  }
+
+  @Test
+  public void of10() {
+    var map = PMap.of(
+      "partridge in a pear tree", 1,
+      "turtle dove", 2,
+      "French hen", 3,
+      "calling bird", 4,
+      "gold ring", 5,
+      "goose a-laying", 6,
+      "swan a-swimming", 7,
+      "maid a-milking", 8,
+      "lady dancing", 9,
+      "lord a-leaping", 10
+    );
+
+    assertThat(getSize(map.entries())).isEqualTo(10);
+    assertThat(map.get("partridge in a pear tree")).isEqualTo(1);
+    assertThat(map.get("turtle dove")).isEqualTo(2);
+    assertThat(map.get("French hen")).isEqualTo(3);
+    assertThat(map.get("calling bird")).isEqualTo(4);
+    assertThat(map.get("gold ring")).isEqualTo(5);
+    assertThat(map.get("goose a-laying")).isEqualTo(6);
+    assertThat(map.get("swan a-swimming")).isEqualTo(7);
+    assertThat(map.get("maid a-milking")).isEqualTo(8);
+    assertThat(map.get("lady dancing")).isEqualTo(9);
+    assertThat(map.get("lord a-leaping")).isEqualTo(10);
+  }
+
+  private static <T> int getSize(Iterable<T> iterable) {
+    int size = 0;
+    var iterator = iterable.iterator();
+    while (iterator.hasNext()) {
+      iterator.next();
+      size++;
+    }
+    return size;
+  }
+}

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/collections/PSetTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/collections/PSetTest.java
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
- * Inc.1 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonarsource.analyzer.commons.collections;
 

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/collections/PSetTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/collections/PSetTest.java
@@ -1,0 +1,242 @@
+/*
+ * SonarSource Analyzers Commons
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc.1 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.analyzer.commons.collections;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class PSetTest {
+  @Test
+  public void dupesAreIgnored() {
+    var set = PSet.of(
+      "banana",
+      "apple",
+      "banana"
+    );
+
+    assertThat(getSize(set)).isEqualTo(2);
+  }
+
+  @Test
+  public void of0() {
+    assertThat(PSet.of()).isSameAs(PCollections.emptySet());
+  }
+
+  @Test
+  public void of1() {
+    var set = PSet.of(
+      "partridge in a pear tree"
+    );
+
+    assertThat(getSize(set)).isEqualTo(1);
+    assertThat(set.contains("partridge in a pear tree")).isTrue();
+  }
+
+  @Test
+  public void of2() {
+    var set = PSet.of(
+      "partridge in a pear tree",
+      "turtle dove"
+    );
+
+    assertThat(getSize(set)).isEqualTo(2);
+    assertThat(set.contains("partridge in a pear tree")).isTrue();
+    assertThat(set.contains("turtle dove")).isTrue();
+  }
+
+  @Test
+  public void of3() {
+    var set = PSet.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen"
+    );
+
+    assertThat(getSize(set)).isEqualTo(3);
+    assertThat(set.contains("partridge in a pear tree")).isTrue();
+    assertThat(set.contains("turtle dove")).isTrue();
+    assertThat(set.contains("French hen")).isTrue();
+  }
+
+  @Test
+  public void of4() {
+    var set = PSet.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen",
+      "calling bird"
+    );
+
+    assertThat(getSize(set)).isEqualTo(4);
+    assertThat(set.contains("partridge in a pear tree")).isTrue();
+    assertThat(set.contains("turtle dove")).isTrue();
+    assertThat(set.contains("French hen")).isTrue();
+    assertThat(set.contains("calling bird")).isTrue();
+  }
+
+  @Test
+  public void of5() {
+    var set = PSet.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen",
+      "calling bird",
+      "gold ring"
+    );
+
+    assertThat(getSize(set)).isEqualTo(5);
+    assertThat(set.contains("partridge in a pear tree")).isTrue();
+    assertThat(set.contains("turtle dove")).isTrue();
+    assertThat(set.contains("French hen")).isTrue();
+    assertThat(set.contains("calling bird")).isTrue();
+    assertThat(set.contains("gold ring")).isTrue();
+  }
+
+  @Test
+  public void of6() {
+    var set = PSet.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen",
+      "calling bird",
+      "gold ring",
+      "geese a-laying"
+    );
+
+    assertThat(getSize(set)).isEqualTo(6);
+    assertThat(set.contains("partridge in a pear tree")).isTrue();
+    assertThat(set.contains("turtle dove")).isTrue();
+    assertThat(set.contains("French hen")).isTrue();
+    assertThat(set.contains("calling bird")).isTrue();
+    assertThat(set.contains("gold ring")).isTrue();
+    assertThat(set.contains("geese a-laying")).isTrue();
+  }
+
+  @Test
+  public void of7() {
+    var set = PSet.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen",
+      "calling bird",
+      "gold ring",
+      "goose a-laying",
+      "swan a-swimming"
+    );
+
+    assertThat(getSize(set)).isEqualTo(7);
+    assertThat(set.contains("partridge in a pear tree")).isTrue();
+    assertThat(set.contains("turtle dove")).isTrue();
+    assertThat(set.contains("French hen")).isTrue();
+    assertThat(set.contains("calling bird")).isTrue();
+    assertThat(set.contains("gold ring")).isTrue();
+    assertThat(set.contains("goose a-laying")).isTrue();
+    assertThat(set.contains("swan a-swimming")).isTrue();
+  }
+
+  @Test
+  public void of8() {
+    var set = PSet.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen",
+      "calling bird",
+      "gold ring",
+      "goose a-laying",
+      "swan a-swimming",
+      "maid a-milking"
+    );
+
+    assertThat(getSize(set)).isEqualTo(8);
+    assertThat(set.contains("partridge in a pear tree")).isTrue();
+    assertThat(set.contains("turtle dove")).isTrue();
+    assertThat(set.contains("French hen")).isTrue();
+    assertThat(set.contains("calling bird")).isTrue();
+    assertThat(set.contains("gold ring")).isTrue();
+    assertThat(set.contains("goose a-laying")).isTrue();
+    assertThat(set.contains("swan a-swimming")).isTrue();
+    assertThat(set.contains("maid a-milking")).isTrue();
+  }
+
+  @Test
+  public void of9() {
+    var set = PSet.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen",
+      "calling bird",
+      "gold ring",
+      "goose a-laying",
+      "swan a-swimming",
+      "maid a-milking",
+      "lady dancing"
+    );
+
+    assertThat(getSize(set)).isEqualTo(9);
+    assertThat(set.contains("partridge in a pear tree")).isTrue();
+    assertThat(set.contains("turtle dove")).isTrue();
+    assertThat(set.contains("French hen")).isTrue();
+    assertThat(set.contains("calling bird")).isTrue();
+    assertThat(set.contains("gold ring")).isTrue();
+    assertThat(set.contains("goose a-laying")).isTrue();
+    assertThat(set.contains("swan a-swimming")).isTrue();
+    assertThat(set.contains("maid a-milking")).isTrue();
+    assertThat(set.contains("lady dancing")).isTrue();
+  }
+
+  @Test
+  public void of10() {
+    var set = PSet.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen",
+      "calling bird",
+      "gold ring",
+      "goose a-laying",
+      "swan a-swimming",
+      "maid a-milking",
+      "lady dancing",
+      "lord a-leaping"
+    );
+
+    assertThat(getSize(set)).isEqualTo(10);
+    assertThat(set.contains("partridge in a pear tree")).isTrue();
+    assertThat(set.contains("turtle dove")).isTrue();
+    assertThat(set.contains("French hen")).isTrue();
+    assertThat(set.contains("calling bird")).isTrue();
+    assertThat(set.contains("gold ring")).isTrue();
+    assertThat(set.contains("goose a-laying")).isTrue();
+    assertThat(set.contains("swan a-swimming")).isTrue();
+    assertThat(set.contains("maid a-milking")).isTrue();
+    assertThat(set.contains("lady dancing")).isTrue();
+    assertThat(set.contains("lord a-leaping")).isTrue();
+  }
+
+  private static <T> int getSize(Iterable<T> iterable) {
+    int size = 0;
+    var iterator = iterable.iterator();
+    while (iterator.hasNext()) {
+      iterator.next();
+      size++;
+    }
+    return size;
+  }
+}

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/collections/PStackTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/collections/PStackTest.java
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
- * Inc.1 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonarsource.analyzer.commons.collections;
 

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/collections/PStackTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/collections/PStackTest.java
@@ -1,0 +1,221 @@
+/*
+ * SonarSource Analyzers Commons
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc.1 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.analyzer.commons.collections;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class PStackTest {
+  @Test
+  public void of0() {
+    assertThat(PStack.of()).isSameAs(PCollections.emptyStack());
+  }
+
+  @Test
+  public void of1() {
+    var stack = PStack.of(
+      "partridge in a pear tree"
+    );
+
+    assertThat(stack.size()).isEqualTo(1);
+    assertThat(stack.peek(0)).isEqualTo("partridge in a pear tree");
+  }
+
+  @Test
+  public void of2() {
+    var stack = PStack.of(
+      "partridge in a pear tree",
+      "turtle dove"
+    );
+
+    assertThat(stack.size()).isEqualTo(2);
+    assertThat(stack.peek(1)).isEqualTo("partridge in a pear tree");
+    assertThat(stack.peek(0)).isEqualTo("turtle dove");
+  }
+
+  @Test
+  public void of3() {
+    var stack = PStack.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen"
+    );
+
+    assertThat(stack.size()).isEqualTo(3);
+    assertThat(stack.peek(2)).isEqualTo("partridge in a pear tree");
+    assertThat(stack.peek(1)).isEqualTo("turtle dove");
+    assertThat(stack.peek(0)).isEqualTo("French hen");
+  }
+
+  @Test
+  public void of4() {
+    var stack = PStack.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen",
+      "calling bird"
+    );
+
+    assertThat(stack.size()).isEqualTo(4);
+    assertThat(stack.peek(3)).isEqualTo("partridge in a pear tree");
+    assertThat(stack.peek(2)).isEqualTo("turtle dove");
+    assertThat(stack.peek(1)).isEqualTo("French hen");
+    assertThat(stack.peek(0)).isEqualTo("calling bird");
+  }
+
+  @Test
+  public void of5() {
+    var stack = PStack.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen",
+      "calling bird",
+      "gold ring"
+    );
+
+    assertThat(stack.size()).isEqualTo(5);
+    assertThat(stack.peek(4)).isEqualTo("partridge in a pear tree");
+    assertThat(stack.peek(3)).isEqualTo("turtle dove");
+    assertThat(stack.peek(2)).isEqualTo("French hen");
+    assertThat(stack.peek(1)).isEqualTo("calling bird");
+    assertThat(stack.peek(0)).isEqualTo("gold ring");
+  }
+
+  @Test
+  public void of6() {
+    var stack = PStack.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen",
+      "calling bird",
+      "gold ring",
+      "geese a-laying"
+    );
+
+    assertThat(stack.size()).isEqualTo(6);
+    assertThat(stack.peek(5)).isEqualTo("partridge in a pear tree");
+    assertThat(stack.peek(4)).isEqualTo("turtle dove");
+    assertThat(stack.peek(3)).isEqualTo("French hen");
+    assertThat(stack.peek(2)).isEqualTo("calling bird");
+    assertThat(stack.peek(1)).isEqualTo("gold ring");
+    assertThat(stack.peek(0)).isEqualTo("geese a-laying");
+  }
+
+  @Test
+  public void of7() {
+    var stack = PStack.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen",
+      "calling bird",
+      "gold ring",
+      "goose a-laying",
+      "swan a-swimming"
+    );
+
+    assertThat(stack.size()).isEqualTo(7);
+    assertThat(stack.peek(6)).isEqualTo("partridge in a pear tree");
+    assertThat(stack.peek(5)).isEqualTo("turtle dove");
+    assertThat(stack.peek(4)).isEqualTo("French hen");
+    assertThat(stack.peek(3)).isEqualTo("calling bird");
+    assertThat(stack.peek(2)).isEqualTo("gold ring");
+    assertThat(stack.peek(1)).isEqualTo("goose a-laying");
+    assertThat(stack.peek(0)).isEqualTo("swan a-swimming");
+  }
+
+  @Test
+  public void of8() {
+    var stack = PStack.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen",
+      "calling bird",
+      "gold ring",
+      "goose a-laying",
+      "swan a-swimming",
+      "maid a-milking"
+    );
+
+    assertThat(stack.size()).isEqualTo(8);
+    assertThat(stack.peek(7)).isEqualTo("partridge in a pear tree");
+    assertThat(stack.peek(6)).isEqualTo("turtle dove");
+    assertThat(stack.peek(5)).isEqualTo("French hen");
+    assertThat(stack.peek(4)).isEqualTo("calling bird");
+    assertThat(stack.peek(3)).isEqualTo("gold ring");
+    assertThat(stack.peek(2)).isEqualTo("goose a-laying");
+    assertThat(stack.peek(1)).isEqualTo("swan a-swimming");
+    assertThat(stack.peek(0)).isEqualTo("maid a-milking");
+  }
+
+  @Test
+  public void of9() {
+    var stack = PStack.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen",
+      "calling bird",
+      "gold ring",
+      "goose a-laying",
+      "swan a-swimming",
+      "maid a-milking",
+      "lady dancing"
+    );
+
+    assertThat(stack.size()).isEqualTo(9);
+    assertThat(stack.peek(8)).isEqualTo("partridge in a pear tree");
+    assertThat(stack.peek(7)).isEqualTo("turtle dove");
+    assertThat(stack.peek(6)).isEqualTo("French hen");
+    assertThat(stack.peek(5)).isEqualTo("calling bird");
+    assertThat(stack.peek(4)).isEqualTo("gold ring");
+    assertThat(stack.peek(3)).isEqualTo("goose a-laying");
+    assertThat(stack.peek(2)).isEqualTo("swan a-swimming");
+    assertThat(stack.peek(1)).isEqualTo("maid a-milking");
+    assertThat(stack.peek(0)).isEqualTo("lady dancing");
+  }
+
+  @Test
+  public void of10() {
+    var stack = PStack.of(
+      "partridge in a pear tree",
+      "turtle dove",
+      "French hen",
+      "calling bird",
+      "gold ring",
+      "goose a-laying",
+      "swan a-swimming",
+      "maid a-milking",
+      "lady dancing",
+      "lord a-leaping"
+    );
+
+    assertThat(stack.size()).isEqualTo(10);
+    assertThat(stack.peek(9)).isEqualTo("partridge in a pear tree");
+    assertThat(stack.peek(8)).isEqualTo("turtle dove");
+    assertThat(stack.peek(7)).isEqualTo("French hen");
+    assertThat(stack.peek(6)).isEqualTo("calling bird");
+    assertThat(stack.peek(5)).isEqualTo("gold ring");
+    assertThat(stack.peek(4)).isEqualTo("goose a-laying");
+    assertThat(stack.peek(3)).isEqualTo("swan a-swimming");
+    assertThat(stack.peek(2)).isEqualTo("maid a-milking");
+    assertThat(stack.peek(1)).isEqualTo("lady dancing");
+    assertThat(stack.peek(0)).isEqualTo("lord a-leaping");
+  }
+}

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/collections/SetUtilsTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/collections/SetUtilsTest.java
@@ -22,7 +22,6 @@ package org.sonarsource.analyzer.commons.collections;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
I added the exact same overloads that Java's `Map, Set, List` have, so up to 10 items each. I think consistency with the JDK outweighs other concerns in this case (e.g., by default SonarLint doesn't like >7 params).