### PR TITLE
ACOMMONS-16: Fix AVLTree iteration when buckets have multiple items

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/collections/TreeIterator.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/collections/TreeIterator.java
@@ -28,20 +28,27 @@ class TreeIterator<K, V> implements Iterator<AVLTree<K, V>> {
 
   private final Deque<AVLTree<K, V>> stack = new ArrayDeque<>();
   private AVLTree<K, V> current;
+  private AVLTree<K, V> inBucket;
 
   TreeIterator(AVLTree<K, V> root) {
     current = root;
+    inBucket = null;
   }
 
   @Override
   public boolean hasNext() {
-    return !stack.isEmpty() || !current.isEmpty();
+    return !stack.isEmpty() || !current.isEmpty() || inBucket != null;
   }
 
   @SuppressWarnings("unchecked")
   public AVLTree<K, V> next() {
     if (!hasNext()) {
       throw new NoSuchElementException();
+    }
+    if (inBucket != null) {
+      var previous = inBucket;
+      inBucket = inBucket.nextInBucket();
+      return previous;
     }
     while (!current.isEmpty()) {
       stack.push(current);
@@ -50,6 +57,7 @@ class TreeIterator<K, V> implements Iterator<AVLTree<K, V>> {
     current = stack.pop();
     AVLTree<K, V> node = current;
     current = current.right();
+    inBucket = node.nextInBucket();
     return node;
   }
 }

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/collections/AVLTreeTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/collections/AVLTreeTest.java
@@ -503,29 +503,73 @@ public class AVLTreeTest {
 
   @Test
   public void test_not_equal_but_same_hashcode_iteration() {
-    var a = new Weird();
-    var b = new Weird();
+    var set = PSet.of(
+      new Weird(0),
+      new Weird(0)
+    );
 
     int count = 0;
-    var set = PSet.of(a, b);
     for (var ignored : set) {
       count++;
     }
+
     assertThat(count).isEqualTo(2);
   }
 
   @Test
   public void test_not_equal_but_same_hashcode_forEach() {
-    var a = new Weird();
-    var b = new Weird();
+    var set = PSet.of(
+      new Weird(0),
+      new Weird(0)
+    );
 
     var count = new AtomicInteger(0);
-    var set = PSet.of(a, b);
     set.forEach(ignored -> count.incrementAndGet());
+
     assertThat(count.get()).isEqualTo(2);
   }
 
+  @Test
+  public void test_not_equal_but_same_hashcode_iteration_many() {
+    var set = PSet.of(
+      new Weird(0),
+      new Weird(42),
+      new Weird(0),
+      new Weird(1),
+      new Weird(42)
+    );
+
+    int count = 0;
+    for (var ignored : set) {
+      count++;
+    }
+
+    assertThat(count).isEqualTo(5);
+  }
+
+  @Test
+  public void test_not_equal_but_same_hashcode_forEach_many() {
+    var set = PSet.of(
+      new Weird(0),
+      new Weird(42),
+      new Weird(0),
+      new Weird(1),
+      new Weird(42)
+    );
+
+    var count = new AtomicInteger(0);
+    set.forEach(ignored -> count.incrementAndGet());
+
+    assertThat(count.get()).isEqualTo(5);
+  }
+
   static class Weird {
+    private final int hashCode;
+
+    public Weird(int hashCode) {
+      this.hashCode = hashCode;
+    }
+
     @Override
     public boolean equals(Object obj) {
       return false;
@@ -533,7 +577,7 @@ public class AVLTreeTest {
 
     @Override
     public int hashCode() {
-      return 0;
+      return hashCode;
     }
   }
 }

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/collections/AVLTreeTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/collections/AVLTreeTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -498,5 +499,41 @@ public class AVLTreeTest {
     stack = stack.push(1).push(2).push(3);
     Stream<Integer> stream = stack.stream();
     assertThat(stream).containsExactly(3, 2, 1);
+  }
+
+  @Test
+  public void test_not_equal_but_same_hashcode_iteration() {
+    var a = new Weird();
+    var b = new Weird();
+
+    int count = 0;
+    var set = PSet.of(a, b);
+    for (var ignored : set) {
+      count++;
+    }
+    assertThat(count).isEqualTo(2);
+  }
+
+  @Test
+  public void test_not_equal_but_same_hashcode_forEach() {
+    var a = new Weird();
+    var b = new Weird();
+
+    var count = new AtomicInteger(0);
+    var set = PSet.of(a, b);
+    set.forEach(ignored -> count.incrementAndGet());
+    assertThat(count.get()).isEqualTo(2);
+  }
+
+  static class Weird {
+    @Override
+    public boolean equals(Object obj) {
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
   }
 }


### PR DESCRIPTION
As I wrote in [the ticket](https://sonarsource.atlassian.net/browse/ACOMMONS-16), the `forEach` test already passed but the `iterator` one did not.

Seems to go all the way back to #240 .