### PR TITLE
SONARXML-146 Allow checks to access SensorContext to read configuration

### DIFF
--- a/test-xml-parsing/src/main/java/org/sonarsource/analyzer/commons/xml/checks/SonarXmlCheckVerifier.java
+++ b/test-xml-parsing/src/main/java/org/sonarsource/analyzer/commons/xml/checks/SonarXmlCheckVerifier.java
@@ -38,6 +38,7 @@ import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.Issue;
 import org.sonar.api.batch.sensor.issue.Issue.Flow;
 import org.sonar.api.batch.sensor.issue.IssueLocation;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.rule.RuleKey;
 import org.sonarsource.analyzer.commons.checks.verifier.SingleFileVerifier;
 import org.sonarsource.analyzer.commons.xml.XmlFile;
@@ -70,11 +71,27 @@ public class SonarXmlCheckVerifier {
     createVerifier(relativePath, check).checkNoIssues();
   }
 
-  private static SonarXmlCheckVerifier createVerifier(String fileName, SonarXmlCheck check) {
-    File file = new File(new File(BASE_DIR.toFile(), check.getClass().getSimpleName()), fileName);
+  public static void verifyIssues(String relativePath, SonarXmlCheck check, MapSettings settings) {
+    createVerifier(relativePath, check, settings).checkIssues();
+  }
 
+  public static void verifyNoIssue(String relativePath, SonarXmlCheck check, MapSettings settings) {
+    createVerifier(relativePath, check, settings).checkNoIssues();
+  }
+
+  private static SonarXmlCheckVerifier createVerifier(String fileName, SonarXmlCheck check, MapSettings settings) {
     SensorContextTester context = SensorContextTester.create(BASE_DIR);
+    context.setSettings(settings);
+    return createVerifier(fileName, check, context);
+  }
 
+  private static SonarXmlCheckVerifier createVerifier(String fileName, SonarXmlCheck check) {
+    SensorContextTester context = SensorContextTester.create(BASE_DIR);
+    return createVerifier(fileName, check, context);
+  }
+
+  private static SonarXmlCheckVerifier createVerifier(String fileName, SonarXmlCheck check, SensorContextTester context) {
+    File file = new File(new File(BASE_DIR.toFile(), check.getClass().getSimpleName()), fileName);
     String filePath = file.getPath();
     String content;
     try (Stream<String> lines = Files.lines(file.toPath())) {

--- a/test-xml-parsing/src/test/java/org/sonarsource/analyzer/commons/xml/checks/SonarXmlCheckVerifierTest.java
+++ b/test-xml-parsing/src/test/java/org/sonarsource/analyzer/commons/xml/checks/SonarXmlCheckVerifierTest.java
@@ -21,18 +21,23 @@ package org.sonarsource.analyzer.commons.xml.checks;
 
 import org.assertj.core.util.Lists;
 import org.junit.Test;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonarsource.analyzer.commons.xml.XmlFile;
 import org.w3c.dom.Element;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SonarXmlCheckVerifierTest {
 
   @Test
   public void test() {
-    SonarXmlCheckVerifier.verifyNoIssue("file.xml", new SilentTestCheck());
+    SilentTestCheck check = new SilentTestCheck();
+    SonarXmlCheckVerifier.verifyNoIssue("file.xml", check);
+    SonarXmlCheckVerifier.verifyNoIssue("file.xml", check, new MapSettings());
     SonarXmlCheckVerifier.verifyIssueOnFile("file.xml", new FileTestCheck(), "Test file level message", 1, 2);
     SonarXmlCheckVerifier.verifyIssues("checkTestFile.xml", new TestCheck());
+    SonarXmlCheckVerifier.verifyIssues("checkTestFile.xml", new TestCheck(), new MapSettings());
   }
 
   @Test

--- a/xml-parsing/src/main/java/org/sonarsource/analyzer/commons/xml/checks/SonarXmlCheck.java
+++ b/xml-parsing/src/main/java/org/sonarsource/analyzer/commons/xml/checks/SonarXmlCheck.java
@@ -52,6 +52,10 @@ public abstract class SonarXmlCheck {
     return ruleKey;
   }
 
+  protected SensorContext getContext() {
+    return context;
+  }
+
   public abstract void scanFile(XmlFile file);
 
   public final void reportIssueOnFile(String message, List<Integer> secondaryLocationLines) {

--- a/xml-parsing/src/test/java/org/sonarsource/analyzer/commons/xml/checks/SonarXmlCheckTest.java
+++ b/xml-parsing/src/test/java/org/sonarsource/analyzer/commons/xml/checks/SonarXmlCheckTest.java
@@ -1,0 +1,43 @@
+/*
+ * SonarSource Analyzers XML Parsing Commons
+ * Copyright (C) 2009-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.analyzer.commons.xml.checks;
+
+import org.junit.Test;
+import org.sonarsource.analyzer.commons.xml.XmlFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class SonarXmlCheckTest {
+
+  @Test
+  public void check_context_null() {
+    DummyCheck check = new DummyCheck();
+    assertThat(check.getContext()).isNull();
+  }
+
+  static class DummyCheck extends SonarXmlCheck {
+    @Override
+    public void scanFile(XmlFile file) {
+      reportIssueOnFile("message", null);
+    }
+  }
+
+}


### PR DESCRIPTION
In the context of implementing XMLChecks that rely on analysis properties, like "sonar.android.minsdkversion.min", which are gathered by the scanners and stored into the `SensorContext.config()`, this PR wants to allow SonarXMLCheck implementations to access the context, and allow the SonarXMLCheckVerifier to pass this kind of configuration to properly test the expected behavior of such checks.