### PR TITLE
CPP-7789 Add shared SonarResolve parser to analyzer commons

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -121,8 +121,8 @@
                 <requireFilesSize>
                   <!-- Warning: Please consider carefully when increasing the size of this shared library, it might have
                   impact on all our analyzers! -->
-                  <minsize>130000</minsize>
-                  <maxsize>140000</maxsize>
+                  <minsize>140000</minsize>
+                  <maxsize>150000</maxsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>
                   </files>

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
@@ -27,20 +27,26 @@ public final class SonarResolve {
 
   public static final String KEYWORD = "sonar-resolve";
 
-  private final int line;
+  private final int directiveLine;
+  private final int targetLine;
   private final IssueResolution.Status status;
   private final Set<RuleKey> ruleKeys;
   private final String justification;
 
-  public SonarResolve(int line, IssueResolution.Status status, Set<RuleKey> ruleKeys, String justification) {
-    this.line = line;
+  public SonarResolve(int directiveLine, int targetLine, IssueResolution.Status status, Set<RuleKey> ruleKeys, String justification) {
+    this.directiveLine = directiveLine;
+    this.targetLine = targetLine;
     this.status = Objects.requireNonNull(status);
     this.ruleKeys = Collections.unmodifiableSet(new LinkedHashSet<>(ruleKeys));
     this.justification = Objects.requireNonNull(justification);
   }
 
-  public int line() {
-    return line;
+  public int directiveLine() {
+    return directiveLine;
+  }
+
+  public int targetLine() {
+    return targetLine;
   }
 
   public IssueResolution.Status status() {
@@ -64,7 +70,8 @@ public final class SonarResolve {
       return false;
     }
     SonarResolve other = (SonarResolve) object;
-    return line == other.line
+    return directiveLine == other.directiveLine
+      && targetLine == other.targetLine
       && status == other.status
       && ruleKeys.equals(other.ruleKeys)
       && justification.equals(other.justification);
@@ -72,13 +79,14 @@ public final class SonarResolve {
 
   @Override
   public int hashCode() {
-    return Objects.hash(line, status, ruleKeys, justification);
+    return Objects.hash(directiveLine, targetLine, status, ruleKeys, justification);
   }
 
   @Override
   public String toString() {
     return "SonarResolve{"
-      + "line=" + line
+      + "directiveLine=" + directiveLine
+      + ", targetLine=" + targetLine
       + ", status=" + status
       + ", ruleKeys=" + ruleKeys
       + ", justification='" + justification + '\''
@@ -96,19 +104,21 @@ public final class SonarResolve {
     private static final String PREFIX = "Invalid sonar-resolve directive: ";
 
     private final StringBuilder accumulatedDirective = new StringBuilder();
-    private final int line;
+    private final int directiveLine;
     private State state = State.INCOMPLETE;
     private SonarResolve result;
     private String errorMessage;
 
-    public Driver(int line) {
-      this.line = line;
+    public Driver(int directiveLine) {
+      this.directiveLine = directiveLine;
     }
 
-    public State consumeLine(String normalizedLine) {
+    // lineNumber is reserved for future features such as supporting relative offsets for target-line computation.
+    // The parameter is part of the API already so analyzers can adopt those features later without another signature change.
+    public State consumeLine(int lineNumber, String lineContent) {
       checkState(state == State.INCOMPLETE, "Cannot consume additional lines after parser reached a terminal state.");
-      appendNormalizedLine(normalizedLine);
-      Parser parser = new Parser(line);
+      appendNormalizedLine(lineContent);
+      Parser parser = new Parser(directiveLine);
       update(parser, parser.parse(accumulatedDirective.toString()));
       return state;
     }
@@ -157,15 +167,15 @@ public final class SonarResolve {
 
     private static final class Parser {
 
-      private final int line;
+      private final int directiveLine;
       private State state = State.INCOMPLETE;
       private String errorMessage;
       private IssueResolution.Status status = IssueResolution.Status.DEFAULT;
       private final Set<RuleKey> ruleKeys = new LinkedHashSet<>();
       private String justification;
 
-      private Parser(int line) {
-        this.line = line;
+      private Parser(int directiveLine) {
+        this.directiveLine = directiveLine;
       }
 
       private State parse(String accumulatedDirective) {
@@ -200,7 +210,7 @@ public final class SonarResolve {
         if (state != State.COMPLETE) {
           return null;
         }
-        return new SonarResolve(line, status, ruleKeys, justification);
+        return new SonarResolve(directiveLine, directiveLine, status, ruleKeys, justification);
       }
 
       private String errorMessage() {

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
@@ -93,7 +93,7 @@ public final class SonarResolve {
       + '}';
   }
 
-  public static final class Driver {
+  public static final class StreamingParser {
 
     public enum State {
       INCOMPLETE,
@@ -109,7 +109,7 @@ public final class SonarResolve {
     private SonarResolve result;
     private String errorMessage;
 
-    public Driver(int directiveLine) {
+    public StreamingParser(int directiveLine) {
       this.directiveLine = directiveLine;
     }
 

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
@@ -1,0 +1,402 @@
+/*
+ * SonarSource Analyzers Commons
+ * Copyright (C) 2009-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.analyzer.commons;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import org.sonar.api.batch.sensor.issue.IssueResolution;
+import org.sonar.api.rule.RuleKey;
+
+public final class SonarResolve {
+
+  public static final String KEYWORD = "sonar-resolve";
+
+  private final int line;
+  private final IssueResolution.Status status;
+  private final Set<RuleKey> ruleKeys;
+  private final String justification;
+
+  public SonarResolve(int line, IssueResolution.Status status, Set<RuleKey> ruleKeys, String justification) {
+    this.line = line;
+    this.status = Objects.requireNonNull(status);
+    this.ruleKeys = Collections.unmodifiableSet(new LinkedHashSet<>(ruleKeys));
+    this.justification = Objects.requireNonNull(justification);
+  }
+
+  public int line() {
+    return line;
+  }
+
+  public IssueResolution.Status status() {
+    return status;
+  }
+
+  public Set<RuleKey> ruleKeys() {
+    return ruleKeys;
+  }
+
+  public String justification() {
+    return justification;
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (!(object instanceof SonarResolve)) {
+      return false;
+    }
+    SonarResolve other = (SonarResolve) object;
+    return line == other.line
+      && status == other.status
+      && ruleKeys.equals(other.ruleKeys)
+      && justification.equals(other.justification);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(line, status, ruleKeys, justification);
+  }
+
+  @Override
+  public String toString() {
+    return "SonarResolve{"
+      + "line=" + line
+      + ", status=" + status
+      + ", ruleKeys=" + ruleKeys
+      + ", justification='" + justification + '\''
+      + '}';
+  }
+
+  public static final class Driver {
+
+    public enum State {
+      INCOMPLETE,
+      COMPLETE,
+      INVALID
+    }
+
+    private static final String PREFIX = "Invalid sonar-resolve directive: ";
+
+    private final StringBuilder accumulatedDirective = new StringBuilder();
+    private final int line;
+    private State state = State.INCOMPLETE;
+    private SonarResolve result;
+    private String errorMessage;
+
+    public Driver(int line) {
+      this.line = line;
+    }
+
+    public State consumeLine(String normalizedLine) {
+      checkState(state == State.INCOMPLETE, "Cannot consume additional lines after parser reached a terminal state.");
+      appendNormalizedLine(normalizedLine);
+      Parser parser = new Parser(line);
+      update(parser, parser.parse(accumulatedDirective.toString()));
+      return state;
+    }
+
+    public State finish() {
+      checkState(accumulatedDirective.length() > 0, "Cannot finish parser before consuming any lines.");
+      if (state == State.INCOMPLETE) {
+        state = State.INVALID;
+        result = null;
+      }
+      return state;
+    }
+
+    public State state() {
+      return state;
+    }
+
+    public SonarResolve result() {
+      checkState(state == State.COMPLETE, "Result is only available when parsing completed successfully.");
+      return result;
+    }
+
+    public String errorMessage() {
+      checkState(state == State.INVALID, "Error message is only available when parsing failed.");
+      return PREFIX + errorMessage;
+    }
+
+    private void appendNormalizedLine(String normalizedLine) {
+      if (accumulatedDirective.length() > 0) {
+        accumulatedDirective.append('\n');
+      }
+      accumulatedDirective.append(normalizedLine);
+    }
+
+    private void update(Parser parser, State parserState) {
+      state = parserState;
+      result = parser.result();
+      errorMessage = parser.errorMessage();
+    }
+
+    private static void checkState(boolean expression, String message) {
+      if (!expression) {
+        throw new IllegalStateException(message);
+      }
+    }
+
+    private static final class Parser {
+
+      private final int line;
+      private State state = State.INCOMPLETE;
+      private String errorMessage;
+      private IssueResolution.Status status = IssueResolution.Status.DEFAULT;
+      private final Set<RuleKey> ruleKeys = new LinkedHashSet<>();
+      private String justification;
+
+      private Parser(int line) {
+        this.line = line;
+      }
+
+      private State parse(String accumulatedDirective) {
+        Cursor cursor = new Cursor(accumulatedDirective);
+        cursor.skipWhitespace();
+
+        if (!cursor.expectLiteral(KEYWORD, "missing '" + KEYWORD + "'")) {
+          return state;
+        }
+
+        if (!cursor.expectWhitespace("expected whitespace after '" + KEYWORD + "'")) {
+          return state;
+        }
+
+        if (!parseStatus(cursor)) {
+          return state;
+        }
+
+        if (!parseRuleKeys(cursor)) {
+          return state;
+        }
+
+        if (!parseJustification(cursor)) {
+          return state;
+        }
+
+        state = State.COMPLETE;
+        return state;
+      }
+
+      private SonarResolve result() {
+        if (state != State.COMPLETE) {
+          return null;
+        }
+        return new SonarResolve(line, status, ruleKeys, justification);
+      }
+
+      private String errorMessage() {
+        return errorMessage;
+      }
+
+      private boolean parseStatus(Cursor cursor) {
+        cursor.skipWhitespace();
+        if (!cursor.consume('[')) {
+          status = IssueResolution.Status.DEFAULT;
+          return true;
+        }
+
+        String statusText = cursor.consumeUntil(']');
+        if (statusText == null) {
+          return incomplete("unterminated status");
+        }
+
+        if ("accept".equals(statusText)) {
+          status = IssueResolution.Status.DEFAULT;
+          return true;
+        }
+        if ("fp".equals(statusText)) {
+          status = IssueResolution.Status.FALSE_POSITIVE;
+          return true;
+        }
+        return invalid("invalid status '[" + statusText + "]'");
+      }
+
+      private boolean parseRuleKeys(Cursor cursor) {
+        ruleKeys.clear();
+        while (true) {
+          cursor.skipWhitespace();
+          if (cursor.isAtEnd()) {
+            return incomplete(ruleKeys.isEmpty() ? "missing rule key" : "invalid rule key list");
+          }
+
+          if (!parseSingleRuleKey(cursor)) {
+            return false;
+          }
+
+          cursor.skipWhitespace();
+          if (!cursor.consume(',')) {
+            return true;
+          }
+        }
+      }
+
+      private boolean parseSingleRuleKey(Cursor cursor) {
+        String ruleKeyText = cursor.consumeWhile(Parser::isRuleKeyChar);
+        if (ruleKeyText.isEmpty()) {
+          if (ruleKeys.isEmpty()) {
+            return invalid("missing rule key");
+          }
+          return invalid("invalid rule key list");
+        }
+
+        RuleKey ruleKey;
+        try {
+          ruleKey = RuleKey.parse(ruleKeyText);
+        } catch (IllegalArgumentException exception) {
+          return invalid("invalid rule key '" + ruleKeyText + "'");
+        }
+        if (!ruleKeys.add(ruleKey)) {
+          return invalid("duplicate rule key '" + ruleKey + "'");
+        }
+        return true;
+      }
+
+      private boolean parseJustification(Cursor cursor) {
+        cursor.skipWhitespace();
+        if (cursor.isAtEnd()) {
+          return incomplete("missing justification");
+        }
+        if (!cursor.consume('"')) {
+          return invalid("missing justification");
+        }
+
+        StringBuilder justificationBuilder = new StringBuilder();
+        boolean escaped = false;
+        while (!cursor.isAtEnd()) {
+          char current = cursor.consume();
+          if (escaped) {
+            justificationBuilder.append(unescape(current));
+            escaped = false;
+          } else if (current == '\\') {
+            escaped = true;
+          } else if (current == '"') {
+            justification = justificationBuilder.toString();
+            return true;
+          } else {
+            justificationBuilder.append(current);
+          }
+        }
+        return incomplete("unterminated justification");
+      }
+
+      private static char unescape(char character) {
+        switch (character) {
+          case 'n':
+            return '\n';
+          case 'r':
+            return '\r';
+          case 't':
+            return '\t';
+          default:
+            return character;
+        }
+      }
+
+      private boolean incomplete(String message) {
+        state = State.INCOMPLETE;
+        errorMessage = message;
+        justification = null;
+        return false;
+      }
+
+      private boolean invalid(String message) {
+        state = State.INVALID;
+        errorMessage = message;
+        justification = null;
+        return false;
+      }
+
+      private static boolean isRuleKeyChar(char character) {
+        return Character.isLetterOrDigit(character) || character == ':' || character == '_';
+      }
+
+      private final class Cursor {
+
+        private final String text;
+        private int index;
+
+        private Cursor(String text) {
+          this.text = text;
+        }
+
+        private boolean isAtEnd() {
+          return index == text.length();
+        }
+
+        private void skipWhitespace() {
+          consumeWhile(Character::isWhitespace);
+        }
+
+        private boolean expectLiteral(String literal, String missingMessage) {
+          return text.startsWith(literal, index) ? advance(literal.length()) : invalid(missingMessage);
+        }
+
+        private boolean expectWhitespace(String message) {
+          if (isAtEnd()) {
+            return true;
+          }
+          if (!Character.isWhitespace(text.charAt(index))) {
+            return invalid(message);
+          }
+          skipWhitespace();
+          return true;
+        }
+
+        private boolean advance(int length) {
+          index += length;
+          return true;
+        }
+
+        private boolean consume(char expected) {
+          if (!isAtEnd() && text.charAt(index) == expected) {
+            index++;
+            return true;
+          }
+          return false;
+        }
+
+        private char consume() {
+          char character = text.charAt(index);
+          index++;
+          return character;
+        }
+
+        private String consumeWhile(CharacterPredicate predicate) {
+          int start = index;
+          while (!isAtEnd() && predicate.test(text.charAt(index))) {
+            index++;
+          }
+          return text.substring(start, index);
+        }
+
+        private String consumeUntil(char delimiter) {
+          String consumed = consumeWhile(character -> character != delimiter);
+          return consume(delimiter) ? consumed : null;
+        }
+      }
+
+      private interface CharacterPredicate {
+        boolean test(char character);
+      }
+    }
+  }
+}

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
@@ -182,7 +182,7 @@ public final class SonarResolve {
         Cursor cursor = new Cursor(accumulatedDirective);
         cursor.skipWhitespace();
 
-        if (!cursor.expectLiteral(KEYWORD, "missing '" + KEYWORD + "'")) {
+        if (!cursor.expectLiteralIgnoreCase(KEYWORD, "missing '" + KEYWORD + "'")) {
           return state;
         }
 
@@ -229,11 +229,11 @@ public final class SonarResolve {
           return incomplete("unterminated status");
         }
 
-        if ("accept".equals(statusText)) {
+        if ("accept".equalsIgnoreCase(statusText)) {
           status = IssueResolution.Status.DEFAULT;
           return true;
         }
-        if ("fp".equals(statusText)) {
+        if ("fp".equalsIgnoreCase(statusText)) {
           status = IssueResolution.Status.FALSE_POSITIVE;
           return true;
         }
@@ -285,9 +285,11 @@ public final class SonarResolve {
         if (cursor.isAtEnd()) {
           return incomplete("missing justification");
         }
-        if (!cursor.consume('"')) {
+        Character closingDelimiter = closingDelimiterFor(cursor.peek());
+        if (closingDelimiter == null) {
           return invalid("missing justification");
         }
+        cursor.consume();
 
         StringBuilder justificationBuilder = new StringBuilder();
         boolean escaped = false;
@@ -298,7 +300,7 @@ public final class SonarResolve {
             escaped = false;
           } else if (current == '\\') {
             escaped = true;
-          } else if (current == '"') {
+          } else if (current == closingDelimiter) {
             justification = justificationBuilder.toString();
             return true;
           } else {
@@ -339,6 +341,25 @@ public final class SonarResolve {
         return Character.isLetterOrDigit(character) || character == ':' || character == '_';
       }
 
+      private static Character closingDelimiterFor(char openingDelimiter) {
+        switch (openingDelimiter) {
+          case '`':
+            return '`';
+          case '\'':
+            return '\'';
+          case '"':
+            return '"';
+          case '(':
+            return ')';
+          case '[':
+            return ']';
+          case '{':
+            return '}';
+          default:
+            return null;
+        }
+      }
+
       private final class Cursor {
 
         private final String text;
@@ -356,8 +377,8 @@ public final class SonarResolve {
           consumeWhile(Character::isWhitespace);
         }
 
-        private boolean expectLiteral(String literal, String missingMessage) {
-          return text.startsWith(literal, index) ? advance(literal.length()) : invalid(missingMessage);
+        private boolean expectLiteralIgnoreCase(String literal, String missingMessage) {
+          return text.regionMatches(true, index, literal, 0, literal.length()) ? advance(literal.length()) : invalid(missingMessage);
         }
 
         private boolean expectWhitespace(String message) {
@@ -382,6 +403,10 @@ public final class SonarResolve {
             return true;
           }
           return false;
+        }
+
+        private char peek() {
+          return text.charAt(index);
         }
 
         private char consume() {

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
@@ -29,17 +29,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-public class SonarResolveTest {
+class SonarResolveTest {
 
   @ParameterizedTest
   @MethodSource("singleLineSuccessCases")
-  public void parse_supports_single_line_syntax(String directive, int line, SonarResolve expected) {
+  void parse_supports_single_line_syntax(String directive, int line, SonarResolve expected) {
     assertThat(parseSingleLine(directive, line)).isEqualTo(expected);
   }
 
   @ParameterizedTest
   @MethodSource("singleLineFailureCases")
-  public void parse_fails_for_invalid_single_line_syntax(String directive, String expectedErrorMessage) {
+  void parse_fails_for_invalid_single_line_syntax(String directive, String expectedErrorMessage) {
     SonarResolve.Driver parser = new SonarResolve.Driver(42);
 
     SonarResolve.Driver.State state = parser.consumeLine(directive);
@@ -53,7 +53,7 @@ public class SonarResolveTest {
 
   @ParameterizedTest
   @MethodSource("multiLineSuccessCases")
-  public void consume_line_supports_multi_line_syntax(String[] lines, int line, SonarResolve expected) {
+  void consume_line_supports_multi_line_syntax(String[] lines, int line, SonarResolve expected) {
     SonarResolve.Driver parser = new SonarResolve.Driver(line);
     for (int i = 0; i < lines.length - 1; i++) {
       assertThat(parser.consumeLine(lines[i])).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
@@ -64,7 +64,7 @@ public class SonarResolveTest {
 
   @ParameterizedTest
   @MethodSource("multiLineFailureCases")
-  public void consume_line_fails_for_invalid_multi_line_syntax(String[] lines, String expectedErrorMessage) {
+  void consume_line_fails_for_invalid_multi_line_syntax(String[] lines, String expectedErrorMessage) {
     SonarResolve.Driver parser = new SonarResolve.Driver(42);
     for (int i = 0; i < lines.length - 1; i++) {
       assertThat(parser.consumeLine(lines[i])).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
@@ -80,7 +80,7 @@ public class SonarResolveTest {
   }
 
   @Test
-  public void finish_before_consuming_any_line_throws() {
+  void finish_before_consuming_any_line_throws() {
     SonarResolve.Driver parser = new SonarResolve.Driver(42);
 
     assertThatThrownBy(parser::finish)
@@ -89,7 +89,7 @@ public class SonarResolveTest {
   }
 
   @Test
-  public void consume_line_after_complete_throws() {
+  void consume_line_after_complete_throws() {
     SonarResolve.Driver parser = new SonarResolve.Driver(42);
     parser.consumeLine("sonar-resolve cpp:S100 \"reason\"");
 
@@ -99,7 +99,7 @@ public class SonarResolveTest {
   }
 
   @Test
-  public void consume_line_after_invalid_throws() {
+  void consume_line_after_invalid_throws() {
     SonarResolve.Driver parser = new SonarResolve.Driver(42);
     parser.consumeLine("sonar-resolve [accepted] cpp:S100 \"reason\"");
 
@@ -109,7 +109,7 @@ public class SonarResolveTest {
   }
 
   @Test
-  public void consume_line_preserves_empty_continuation_lines_inside_justification() {
+  void consume_line_preserves_empty_continuation_lines_inside_justification() {
     SonarResolve.Driver parser = new SonarResolve.Driver(42);
 
     assertThat(parser.consumeLine("sonar-resolve cpp:S100 \"line1")).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
@@ -42,7 +42,7 @@ class SonarResolveTest {
   void parse_fails_for_invalid_single_line_syntax(String directive, String expectedErrorMessage) {
     SonarResolve.Driver parser = new SonarResolve.Driver(42);
 
-    SonarResolve.Driver.State state = parser.consumeLine(directive);
+    SonarResolve.Driver.State state = parser.consumeLine(42, directive);
     if (state == SonarResolve.Driver.State.INCOMPLETE) {
       state = parser.finish();
     }
@@ -56,9 +56,9 @@ class SonarResolveTest {
   void consume_line_supports_multi_line_syntax(String[] lines, int line, SonarResolve expected) {
     SonarResolve.Driver parser = new SonarResolve.Driver(line);
     for (int i = 0; i < lines.length - 1; i++) {
-      assertThat(parser.consumeLine(lines[i])).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
+      assertThat(parser.consumeLine(line + i, lines[i])).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
     }
-    assertThat(parser.consumeLine(lines[lines.length - 1])).isEqualTo(SonarResolve.Driver.State.COMPLETE);
+    assertThat(parser.consumeLine(line + lines.length - 1, lines[lines.length - 1])).isEqualTo(SonarResolve.Driver.State.COMPLETE);
     assertThat(parser.result()).isEqualTo(expected);
   }
 
@@ -67,10 +67,10 @@ class SonarResolveTest {
   void consume_line_fails_for_invalid_multi_line_syntax(String[] lines, String expectedErrorMessage) {
     SonarResolve.Driver parser = new SonarResolve.Driver(42);
     for (int i = 0; i < lines.length - 1; i++) {
-      assertThat(parser.consumeLine(lines[i])).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
+      assertThat(parser.consumeLine(42 + i, lines[i])).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
     }
 
-    SonarResolve.Driver.State state = parser.consumeLine(lines[lines.length - 1]);
+    SonarResolve.Driver.State state = parser.consumeLine(42 + lines.length - 1, lines[lines.length - 1]);
     if (state == SonarResolve.Driver.State.INCOMPLETE) {
       state = parser.finish();
     }
@@ -91,9 +91,9 @@ class SonarResolveTest {
   @Test
   void consume_line_after_complete_throws() {
     SonarResolve.Driver parser = new SonarResolve.Driver(42);
-    parser.consumeLine("sonar-resolve cpp:S100 \"reason\"");
+    assertThat(parser.consumeLine(42, "sonar-resolve cpp:S100 \"reason\"")).isEqualTo(SonarResolve.Driver.State.COMPLETE);
 
-    assertThatThrownBy(() -> parser.consumeLine("ignored"))
+    assertThatThrownBy(() -> parser.consumeLine(43, "ignored"))
       .isInstanceOf(IllegalStateException.class)
       .hasMessage("Cannot consume additional lines after parser reached a terminal state.");
   }
@@ -101,9 +101,9 @@ class SonarResolveTest {
   @Test
   void consume_line_after_invalid_throws() {
     SonarResolve.Driver parser = new SonarResolve.Driver(42);
-    parser.consumeLine("sonar-resolve [accepted] cpp:S100 \"reason\"");
+    assertThat(parser.consumeLine(42, "sonar-resolve [accepted] cpp:S100 \"reason\"")).isEqualTo(SonarResolve.Driver.State.INVALID);
 
-    assertThatThrownBy(() -> parser.consumeLine("ignored"))
+    assertThatThrownBy(() -> parser.consumeLine(43, "ignored"))
       .isInstanceOf(IllegalStateException.class)
       .hasMessage("Cannot consume additional lines after parser reached a terminal state.");
   }
@@ -112,17 +112,17 @@ class SonarResolveTest {
   void consume_line_preserves_empty_continuation_lines_inside_justification() {
     SonarResolve.Driver parser = new SonarResolve.Driver(42);
 
-    assertThat(parser.consumeLine("sonar-resolve cpp:S100 \"line1")).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
-    assertThat(parser.consumeLine("")).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
-    assertThat(parser.consumeLine("line3\"")).isEqualTo(SonarResolve.Driver.State.COMPLETE);
+    assertThat(parser.consumeLine(42, "sonar-resolve cpp:S100 \"line1")).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
+    assertThat(parser.consumeLine(43, "")).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
+    assertThat(parser.consumeLine(44, "line3\"")).isEqualTo(SonarResolve.Driver.State.COMPLETE);
 
     assertThat(parser.result()).isEqualTo(
-      new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line1\n\nline3"));
+      new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line1\n\nline3"));
   }
 
   private static SonarResolve parseSingleLine(String directive, int line) {
     SonarResolve.Driver parser = new SonarResolve.Driver(line);
-    assertThat(parser.consumeLine(directive)).isEqualTo(SonarResolve.Driver.State.COMPLETE);
+    assertThat(parser.consumeLine(line, directive)).isEqualTo(SonarResolve.Driver.State.COMPLETE);
     return parser.result();
   }
 
@@ -131,11 +131,12 @@ class SonarResolveTest {
       arguments(
         "sonar-resolve cpp:S100 \"line comment\"",
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
       arguments(
         "sonar-resolve cpp:S100, cpp:M23_123,c:S200 , objc:S300 \"line comment\"",
         42,
         new SonarResolve(
+          42,
           42,
           IssueResolution.Status.DEFAULT,
           Set.of(
@@ -147,15 +148,16 @@ class SonarResolveTest {
       arguments(
         "sonar-resolve [accept] cpp:S100 \"line comment\"",
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
       arguments(
         "sonar-resolve [fp] cpp:S100 \"line comment\"",
         42,
-        new SonarResolve(42, IssueResolution.Status.FALSE_POSITIVE, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+        new SonarResolve(42, 42, IssueResolution.Status.FALSE_POSITIVE, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
       arguments(
         "sonar-resolve [fp] cpp:S100, cpp:M23_123 \"line comment\"",
         42,
         new SonarResolve(
+          42,
           42,
           IssueResolution.Status.FALSE_POSITIVE,
           Set.of(RuleKey.of("cpp", "S100"), RuleKey.of("cpp", "M23_123")),
@@ -163,11 +165,12 @@ class SonarResolveTest {
       arguments(
         "sonar-resolve cpp:S100 \"line \\\"comment\\\"\"",
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line \"comment\"")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line \"comment\"")),
       arguments(
         "sonar-resolve cpp:S100 \"line\\nline\\rline\\tline\\\\line\"",
         42,
         new SonarResolve(
+          42,
           42,
           IssueResolution.Status.DEFAULT,
           Set.of(RuleKey.of("cpp", "S100")),
@@ -197,14 +200,14 @@ class SonarResolveTest {
           "cpp:S1234 \"reason\""
         },
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "reason")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "reason")),
       arguments(
         new String[] {
           "sonar-resolve cpp:S1234 \"reason",
           "reason\""
         },
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "reason\nreason")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "reason\nreason")),
       arguments(
         new String[] {
           "sonar-resolve cpp:S1234 \"first",
@@ -212,7 +215,7 @@ class SonarResolveTest {
           "third\""
         },
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first\nsecond\nthird")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first\nsecond\nthird")),
       arguments(
         new String[] {
           "sonar-resolve",
@@ -223,6 +226,7 @@ class SonarResolveTest {
         },
         42,
         new SonarResolve(
+          42,
           42,
           IssueResolution.Status.FALSE_POSITIVE,
           Set.of(RuleKey.of("cpp", "S100"), RuleKey.of("cpp", "M23_123")),
@@ -235,6 +239,7 @@ class SonarResolveTest {
         42,
         new SonarResolve(
           42,
+          42,
           IssueResolution.Status.DEFAULT,
           Set.of(RuleKey.of("cpp", "S100"), RuleKey.of("cpp", "M23_123")),
           "reason")),
@@ -246,6 +251,7 @@ class SonarResolveTest {
         },
         42,
         new SonarResolve(
+          42,
           42,
           IssueResolution.Status.DEFAULT,
           Set.of(RuleKey.of("cpp", "S1234")),

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
@@ -1,0 +1,288 @@
+/*
+ * SonarSource Analyzers Commons
+ * Copyright (C) 2009-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.analyzer.commons;
+
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.sonar.api.batch.sensor.issue.IssueResolution;
+import org.sonar.api.rule.RuleKey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class SonarResolveTest {
+
+  @ParameterizedTest
+  @MethodSource("singleLineSuccessCases")
+  public void parse_supports_single_line_syntax(String directive, int line, SonarResolve expected) {
+    assertThat(parseSingleLine(directive, line)).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("singleLineFailureCases")
+  public void parse_fails_for_invalid_single_line_syntax(String directive, String expectedErrorMessage) {
+    SonarResolve.Driver parser = new SonarResolve.Driver(42);
+
+    SonarResolve.Driver.State state = parser.consumeLine(directive);
+    if (state == SonarResolve.Driver.State.INCOMPLETE) {
+      state = parser.finish();
+    }
+
+    assertThat(state).isEqualTo(SonarResolve.Driver.State.INVALID);
+    assertThat(parser.errorMessage()).isEqualTo(expectedErrorMessage);
+  }
+
+  @ParameterizedTest
+  @MethodSource("multiLineSuccessCases")
+  public void consume_line_supports_multi_line_syntax(String[] lines, int line, SonarResolve expected) {
+    SonarResolve.Driver parser = new SonarResolve.Driver(line);
+    for (int i = 0; i < lines.length - 1; i++) {
+      assertThat(parser.consumeLine(lines[i])).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
+    }
+    assertThat(parser.consumeLine(lines[lines.length - 1])).isEqualTo(SonarResolve.Driver.State.COMPLETE);
+    assertThat(parser.result()).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("multiLineFailureCases")
+  public void consume_line_fails_for_invalid_multi_line_syntax(String[] lines, String expectedErrorMessage) {
+    SonarResolve.Driver parser = new SonarResolve.Driver(42);
+    for (int i = 0; i < lines.length - 1; i++) {
+      assertThat(parser.consumeLine(lines[i])).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
+    }
+
+    SonarResolve.Driver.State state = parser.consumeLine(lines[lines.length - 1]);
+    if (state == SonarResolve.Driver.State.INCOMPLETE) {
+      state = parser.finish();
+    }
+
+    assertThat(state).isEqualTo(SonarResolve.Driver.State.INVALID);
+    assertThat(parser.errorMessage()).isEqualTo(expectedErrorMessage);
+  }
+
+  @Test
+  public void finish_before_consuming_any_line_throws() {
+    SonarResolve.Driver parser = new SonarResolve.Driver(42);
+
+    assertThatThrownBy(parser::finish)
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Cannot finish parser before consuming any lines.");
+  }
+
+  @Test
+  public void consume_line_after_complete_throws() {
+    SonarResolve.Driver parser = new SonarResolve.Driver(42);
+    parser.consumeLine("sonar-resolve cpp:S100 \"reason\"");
+
+    assertThatThrownBy(() -> parser.consumeLine("ignored"))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Cannot consume additional lines after parser reached a terminal state.");
+  }
+
+  @Test
+  public void consume_line_after_invalid_throws() {
+    SonarResolve.Driver parser = new SonarResolve.Driver(42);
+    parser.consumeLine("sonar-resolve [accepted] cpp:S100 \"reason\"");
+
+    assertThatThrownBy(() -> parser.consumeLine("ignored"))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Cannot consume additional lines after parser reached a terminal state.");
+  }
+
+  @Test
+  public void consume_line_preserves_empty_continuation_lines_inside_justification() {
+    SonarResolve.Driver parser = new SonarResolve.Driver(42);
+
+    assertThat(parser.consumeLine("sonar-resolve cpp:S100 \"line1")).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
+    assertThat(parser.consumeLine("")).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
+    assertThat(parser.consumeLine("line3\"")).isEqualTo(SonarResolve.Driver.State.COMPLETE);
+
+    assertThat(parser.result()).isEqualTo(
+      new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line1\n\nline3"));
+  }
+
+  private static SonarResolve parseSingleLine(String directive, int line) {
+    SonarResolve.Driver parser = new SonarResolve.Driver(line);
+    assertThat(parser.consumeLine(directive)).isEqualTo(SonarResolve.Driver.State.COMPLETE);
+    return parser.result();
+  }
+
+  private static Stream<Arguments> singleLineSuccessCases() {
+    return Stream.of(
+      arguments(
+        "sonar-resolve cpp:S100 \"line comment\"",
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
+        "sonar-resolve cpp:S100, cpp:M23_123,c:S200 , objc:S300 \"line comment\"",
+        42,
+        new SonarResolve(
+          42,
+          IssueResolution.Status.DEFAULT,
+          Set.of(
+            RuleKey.of("cpp", "S100"),
+            RuleKey.of("cpp", "M23_123"),
+            RuleKey.of("c", "S200"),
+            RuleKey.of("objc", "S300")),
+          "line comment")),
+      arguments(
+        "sonar-resolve [accept] cpp:S100 \"line comment\"",
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
+        "sonar-resolve [fp] cpp:S100 \"line comment\"",
+        42,
+        new SonarResolve(42, IssueResolution.Status.FALSE_POSITIVE, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
+        "sonar-resolve [fp] cpp:S100, cpp:M23_123 \"line comment\"",
+        42,
+        new SonarResolve(
+          42,
+          IssueResolution.Status.FALSE_POSITIVE,
+          Set.of(RuleKey.of("cpp", "S100"), RuleKey.of("cpp", "M23_123")),
+          "line comment")),
+      arguments(
+        "sonar-resolve cpp:S100 \"line \\\"comment\\\"\"",
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line \"comment\"")),
+      arguments(
+        "sonar-resolve cpp:S100 \"line\\nline\\rline\\tline\\\\line\"",
+        42,
+        new SonarResolve(
+          42,
+          IssueResolution.Status.DEFAULT,
+          Set.of(RuleKey.of("cpp", "S100")),
+          "line\nline\rline\tline\\line")));
+  }
+
+  private static Stream<Arguments> singleLineFailureCases() {
+    return Stream.of(
+      arguments("cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: missing 'sonar-resolve'"),
+      arguments("sonar-resolvecpp:S100 \"line comment\"", "Invalid sonar-resolve directive: expected whitespace after 'sonar-resolve'"),
+      arguments("sonar-resolve[fp] cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: expected whitespace after 'sonar-resolve'"),
+      arguments("sonar-resolve \"line comment\"", "Invalid sonar-resolve directive: missing rule key"),
+      arguments("sonar-resolve cppS1234 \"line comment\"", "Invalid sonar-resolve directive: invalid rule key 'cppS1234'"),
+      arguments("sonar-resolve [accepted] cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: invalid status '[accepted]'"),
+      arguments("sonar-resolve [fp cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: unterminated status"),
+      arguments("sonar-resolve cpp:S100, cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: duplicate rule key 'cpp:S100'"),
+      arguments("sonar-resolve cpp:S100, \"line comment\"", "Invalid sonar-resolve directive: invalid rule key list"),
+      arguments("sonar-resolve cpp:S100", "Invalid sonar-resolve directive: missing justification"),
+      arguments("sonar-resolve cpp:S100 \"line comment", "Invalid sonar-resolve directive: unterminated justification"));
+  }
+
+  private static Stream<Arguments> multiLineSuccessCases() {
+    return Stream.of(
+      arguments(
+        new String[] {
+          "sonar-resolve",
+          "cpp:S1234 \"reason\""
+        },
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "reason")),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S1234 \"reason",
+          "reason\""
+        },
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "reason\nreason")),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S1234 \"first",
+          "second",
+          "third\""
+        },
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first\nsecond\nthird")),
+      arguments(
+        new String[] {
+          "sonar-resolve",
+          "[fp]",
+          "cpp:S100,",
+          "cpp:M23_123",
+          "\"reason\""
+        },
+        42,
+        new SonarResolve(
+          42,
+          IssueResolution.Status.FALSE_POSITIVE,
+          Set.of(RuleKey.of("cpp", "S100"), RuleKey.of("cpp", "M23_123")),
+          "reason")),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S100,",
+          "cpp:M23_123 \"reason\""
+        },
+        42,
+        new SonarResolve(
+          42,
+          IssueResolution.Status.DEFAULT,
+          Set.of(RuleKey.of("cpp", "S100"), RuleKey.of("cpp", "M23_123")),
+          "reason")),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S1234 \"prefix\\n",
+          "middle\\t",
+          "suffix\\\"\""
+        },
+        42,
+        new SonarResolve(
+          42,
+          IssueResolution.Status.DEFAULT,
+          Set.of(RuleKey.of("cpp", "S1234")),
+          "prefix\n\nmiddle\t\nsuffix\"")));
+  }
+
+  private static Stream<Arguments> multiLineFailureCases() {
+    return Stream.of(
+      arguments(
+        new String[] {
+          "sonar-resolve [f",
+          "p] cpp:S100 \"reason\""
+        },
+        "Invalid sonar-resolve directive: invalid status '[f\np]'"),
+      arguments(
+        new String[] {
+          "sonar-resolve",
+          "\"reason\""
+        },
+        "Invalid sonar-resolve directive: missing rule key"),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S100,",
+          "\"reason\""
+        },
+        "Invalid sonar-resolve directive: invalid rule key list"),
+      arguments(
+        new String[] {
+          "sonar-resolve [fp",
+          "cpp:S100 \"reason\""
+        },
+        "Invalid sonar-resolve directive: unterminated status"),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S100 \"reason",
+          "still reason"
+        },
+        "Invalid sonar-resolve directive: unterminated justification"));
+  }
+}

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
@@ -40,48 +40,48 @@ class SonarResolveTest {
   @ParameterizedTest
   @MethodSource("singleLineFailureCases")
   void parse_fails_for_invalid_single_line_syntax(String directive, String expectedErrorMessage) {
-    SonarResolve.Driver parser = new SonarResolve.Driver(42);
+    SonarResolve.StreamingParser parser = new SonarResolve.StreamingParser(42);
 
-    SonarResolve.Driver.State state = parser.consumeLine(42, directive);
-    if (state == SonarResolve.Driver.State.INCOMPLETE) {
+    SonarResolve.StreamingParser.State state = parser.consumeLine(42, directive);
+    if (state == SonarResolve.StreamingParser.State.INCOMPLETE) {
       state = parser.finish();
     }
 
-    assertThat(state).isEqualTo(SonarResolve.Driver.State.INVALID);
+    assertThat(state).isEqualTo(SonarResolve.StreamingParser.State.INVALID);
     assertThat(parser.errorMessage()).isEqualTo(expectedErrorMessage);
   }
 
   @ParameterizedTest
   @MethodSource("multiLineSuccessCases")
   void consume_line_supports_multi_line_syntax(String[] lines, int line, SonarResolve expected) {
-    SonarResolve.Driver parser = new SonarResolve.Driver(line);
+    SonarResolve.StreamingParser parser = new SonarResolve.StreamingParser(line);
     for (int i = 0; i < lines.length - 1; i++) {
-      assertThat(parser.consumeLine(line + i, lines[i])).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
+      assertThat(parser.consumeLine(line + i, lines[i])).isEqualTo(SonarResolve.StreamingParser.State.INCOMPLETE);
     }
-    assertThat(parser.consumeLine(line + lines.length - 1, lines[lines.length - 1])).isEqualTo(SonarResolve.Driver.State.COMPLETE);
+    assertThat(parser.consumeLine(line + lines.length - 1, lines[lines.length - 1])).isEqualTo(SonarResolve.StreamingParser.State.COMPLETE);
     assertThat(parser.result()).isEqualTo(expected);
   }
 
   @ParameterizedTest
   @MethodSource("multiLineFailureCases")
   void consume_line_fails_for_invalid_multi_line_syntax(String[] lines, String expectedErrorMessage) {
-    SonarResolve.Driver parser = new SonarResolve.Driver(42);
+    SonarResolve.StreamingParser parser = new SonarResolve.StreamingParser(42);
     for (int i = 0; i < lines.length - 1; i++) {
-      assertThat(parser.consumeLine(42 + i, lines[i])).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
+      assertThat(parser.consumeLine(42 + i, lines[i])).isEqualTo(SonarResolve.StreamingParser.State.INCOMPLETE);
     }
 
-    SonarResolve.Driver.State state = parser.consumeLine(42 + lines.length - 1, lines[lines.length - 1]);
-    if (state == SonarResolve.Driver.State.INCOMPLETE) {
+    SonarResolve.StreamingParser.State state = parser.consumeLine(42 + lines.length - 1, lines[lines.length - 1]);
+    if (state == SonarResolve.StreamingParser.State.INCOMPLETE) {
       state = parser.finish();
     }
 
-    assertThat(state).isEqualTo(SonarResolve.Driver.State.INVALID);
+    assertThat(state).isEqualTo(SonarResolve.StreamingParser.State.INVALID);
     assertThat(parser.errorMessage()).isEqualTo(expectedErrorMessage);
   }
 
   @Test
   void finish_before_consuming_any_line_throws() {
-    SonarResolve.Driver parser = new SonarResolve.Driver(42);
+    SonarResolve.StreamingParser parser = new SonarResolve.StreamingParser(42);
 
     assertThatThrownBy(parser::finish)
       .isInstanceOf(IllegalStateException.class)
@@ -90,8 +90,8 @@ class SonarResolveTest {
 
   @Test
   void consume_line_after_complete_throws() {
-    SonarResolve.Driver parser = new SonarResolve.Driver(42);
-    assertThat(parser.consumeLine(42, "sonar-resolve cpp:S100 \"reason\"")).isEqualTo(SonarResolve.Driver.State.COMPLETE);
+    SonarResolve.StreamingParser parser = new SonarResolve.StreamingParser(42);
+    assertThat(parser.consumeLine(42, "sonar-resolve cpp:S100 \"reason\"")).isEqualTo(SonarResolve.StreamingParser.State.COMPLETE);
 
     assertThatThrownBy(() -> parser.consumeLine(43, "ignored"))
       .isInstanceOf(IllegalStateException.class)
@@ -100,8 +100,8 @@ class SonarResolveTest {
 
   @Test
   void consume_line_after_invalid_throws() {
-    SonarResolve.Driver parser = new SonarResolve.Driver(42);
-    assertThat(parser.consumeLine(42, "sonar-resolve [accepted] cpp:S100 \"reason\"")).isEqualTo(SonarResolve.Driver.State.INVALID);
+    SonarResolve.StreamingParser parser = new SonarResolve.StreamingParser(42);
+    assertThat(parser.consumeLine(42, "sonar-resolve [accepted] cpp:S100 \"reason\"")).isEqualTo(SonarResolve.StreamingParser.State.INVALID);
 
     assertThatThrownBy(() -> parser.consumeLine(43, "ignored"))
       .isInstanceOf(IllegalStateException.class)
@@ -110,19 +110,19 @@ class SonarResolveTest {
 
   @Test
   void consume_line_preserves_empty_continuation_lines_inside_justification() {
-    SonarResolve.Driver parser = new SonarResolve.Driver(42);
+    SonarResolve.StreamingParser parser = new SonarResolve.StreamingParser(42);
 
-    assertThat(parser.consumeLine(42, "sonar-resolve cpp:S100 \"line1")).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
-    assertThat(parser.consumeLine(43, "")).isEqualTo(SonarResolve.Driver.State.INCOMPLETE);
-    assertThat(parser.consumeLine(44, "line3\"")).isEqualTo(SonarResolve.Driver.State.COMPLETE);
+    assertThat(parser.consumeLine(42, "sonar-resolve cpp:S100 \"line1")).isEqualTo(SonarResolve.StreamingParser.State.INCOMPLETE);
+    assertThat(parser.consumeLine(43, "")).isEqualTo(SonarResolve.StreamingParser.State.INCOMPLETE);
+    assertThat(parser.consumeLine(44, "line3\"")).isEqualTo(SonarResolve.StreamingParser.State.COMPLETE);
 
     assertThat(parser.result()).isEqualTo(
       new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line1\n\nline3"));
   }
 
   private static SonarResolve parseSingleLine(String directive, int line) {
-    SonarResolve.Driver parser = new SonarResolve.Driver(line);
-    assertThat(parser.consumeLine(line, directive)).isEqualTo(SonarResolve.Driver.State.COMPLETE);
+    SonarResolve.StreamingParser parser = new SonarResolve.StreamingParser(line);
+    assertThat(parser.consumeLine(line, directive)).isEqualTo(SonarResolve.StreamingParser.State.COMPLETE);
     return parser.result();
   }
 

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
@@ -167,6 +167,10 @@ class SonarResolveTest {
         42,
         new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line \"comment\"")),
       arguments(
+        "sonar-resolve cpp:S100 \"line comment\" the rest is ignored",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
         "sonar-resolve cpp:S100 \"line\\nline\\rline\\tline\\\\line\"",
         42,
         new SonarResolve(
@@ -247,7 +251,7 @@ class SonarResolveTest {
         new String[] {
           "sonar-resolve cpp:S1234 \"prefix\\n",
           "middle\\t",
-          "suffix\\\"\""
+          "suffix\\\"\" the rest is ignored"
         },
         42,
         new SonarResolve(

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
@@ -163,6 +163,42 @@ class SonarResolveTest {
           Set.of(RuleKey.of("cpp", "S100"), RuleKey.of("cpp", "M23_123")),
           "line comment")),
       arguments(
+        "SONAR-RESOLVE cpp:S100 \"line comment\"",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
+        "Sonar-Resolve [FP] cpp:S100 \"line comment\"",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.FALSE_POSITIVE, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
+        "sOnAr-ReSoLvE [AcCePt] cpp:S100 \"line comment\"",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
+        "sonar-resolve cpp:S100 `line comment`",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
+        "sonar-resolve cpp:S100 'line \\'comment\\''",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line 'comment'")),
+      arguments(
+        "sonar-resolve cpp:S100 (line comment)",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
+        "sonar-resolve cpp:S100 [line \\]comment]",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line ]comment")),
+      arguments(
+        "sonar-resolve cpp:S100 [line comment)]",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment)")),
+      arguments(
+        "sonar-resolve cpp:S100 {line comment}",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
         "sonar-resolve cpp:S100 \"line \\\"comment\\\"\"",
         42,
         new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line \"comment\"")),
@@ -189,18 +225,22 @@ class SonarResolveTest {
       arguments("sonar-resolve \"line comment\"", "Invalid sonar-resolve directive: missing rule key"),
       arguments("sonar-resolve cppS1234 \"line comment\"", "Invalid sonar-resolve directive: invalid rule key 'cppS1234'"),
       arguments("sonar-resolve [accepted] cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: invalid status '[accepted]'"),
+      arguments("sonar-resolve [Accepted] cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: invalid status '[Accepted]'"),
       arguments("sonar-resolve [fp cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: unterminated status"),
       arguments("sonar-resolve cpp:S100, cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: duplicate rule key 'cpp:S100'"),
       arguments("sonar-resolve cpp:S100, \"line comment\"", "Invalid sonar-resolve directive: invalid rule key list"),
       arguments("sonar-resolve cpp:S100", "Invalid sonar-resolve directive: missing justification"),
-      arguments("sonar-resolve cpp:S100 \"line comment", "Invalid sonar-resolve directive: unterminated justification"));
+      arguments("sonar-resolve cpp:S100 <line comment>", "Invalid sonar-resolve directive: missing justification"),
+      arguments("sonar-resolve cpp:S100 \"line comment", "Invalid sonar-resolve directive: unterminated justification"),
+      arguments("sonar-resolve cpp:S100 [line comment", "Invalid sonar-resolve directive: unterminated justification"),
+      arguments("sonar-resolve cpp:S100 {line comment", "Invalid sonar-resolve directive: unterminated justification"));
   }
 
   private static Stream<Arguments> multiLineSuccessCases() {
     return Stream.of(
       arguments(
         new String[] {
-          "sonar-resolve",
+          "SONAR-RESOLVE",
           "cpp:S1234 \"reason\""
         },
         42,
@@ -222,8 +262,8 @@ class SonarResolveTest {
         new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first\nsecond\nthird")),
       arguments(
         new String[] {
-          "sonar-resolve",
-          "[fp]",
+          "Sonar-Resolve",
+          "[FP]",
           "cpp:S100,",
           "cpp:M23_123",
           "\"reason\""
@@ -259,7 +299,21 @@ class SonarResolveTest {
           42,
           IssueResolution.Status.DEFAULT,
           Set.of(RuleKey.of("cpp", "S1234")),
-          "prefix\n\nmiddle\t\nsuffix\"")));
+          "prefix\n\nmiddle\t\nsuffix\"")),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S1234 [first line",
+          "second line]"
+        },
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first line\nsecond line")),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S1234 [first line)",
+          "second line]"
+        },
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first line)\nsecond line")));
   }
 
   private static Stream<Arguments> multiLineFailureCases() {
@@ -291,6 +345,12 @@ class SonarResolveTest {
       arguments(
         new String[] {
           "sonar-resolve cpp:S100 \"reason",
+          "still reason"
+        },
+        "Invalid sonar-resolve directive: unterminated justification"),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S100 [reason",
           "still reason"
         },
         "Invalid sonar-resolve directive: unterminated justification"));

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
   <properties>
     <!-- versions -->
-    <version.sonar.plugin.api>13.3.0.3209</version.sonar.plugin.api>
+    <version.sonar.plugin.api>13.5.0.4319</version.sonar.plugin.api>
     <sonarqube.api.impl.version>10.7.0.96327</sonarqube.api.impl.version>
     <version.assertj>3.17.1</version.assertj>
     <version.jsr305>3.0.2</version.jsr305>


### PR DESCRIPTION
This PR moves the `SonarResolve` parser to `sonar-analyzer-commons` so it can be reused by other analyzers.

The initial implementation was released in CFamily 6.79. The main reason for moving it here is that we now need to improve and share the parsing logic, especially around code-formatting cases that can split or otherwise alter comments across multiple lines and break `sonar-resolve` directives.

This PR adds the shared parser and its tests to analyzer commons so follow-up fixes and enhancements can be implemented once and consumed from a common place. It is consumed in https://github.com/SonarSource/sonar-cpp/pull/6115.