### PR TITLE
CPP-7901 Make SonarResolve parser case-insensitive

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
@@ -182,7 +182,7 @@ public final class SonarResolve {
         Cursor cursor = new Cursor(accumulatedDirective);
         cursor.skipWhitespace();
 
-        if (!cursor.expectLiteral(KEYWORD, "missing '" + KEYWORD + "'")) {
+        if (!cursor.expectLiteralIgnoreCase(KEYWORD, "missing '" + KEYWORD + "'")) {
           return state;
         }
 
@@ -229,11 +229,11 @@ public final class SonarResolve {
           return incomplete("unterminated status");
         }
 
-        if ("accept".equals(statusText)) {
+        if ("accept".equalsIgnoreCase(statusText)) {
           status = IssueResolution.Status.DEFAULT;
           return true;
         }
-        if ("fp".equals(statusText)) {
+        if ("fp".equalsIgnoreCase(statusText)) {
           status = IssueResolution.Status.FALSE_POSITIVE;
           return true;
         }
@@ -356,8 +356,8 @@ public final class SonarResolve {
           consumeWhile(Character::isWhitespace);
         }
 
-        private boolean expectLiteral(String literal, String missingMessage) {
-          return text.startsWith(literal, index) ? advance(literal.length()) : invalid(missingMessage);
+        private boolean expectLiteralIgnoreCase(String literal, String missingMessage) {
+          return text.regionMatches(true, index, literal, 0, literal.length()) ? advance(literal.length()) : invalid(missingMessage);
         }
 
         private boolean expectWhitespace(String message) {

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
@@ -285,9 +285,11 @@ public final class SonarResolve {
         if (cursor.isAtEnd()) {
           return incomplete("missing justification");
         }
-        if (!cursor.consume('"')) {
+        Character closingDelimiter = closingDelimiterFor(cursor.peek());
+        if (closingDelimiter == null) {
           return invalid("missing justification");
         }
+        cursor.consume();
 
         StringBuilder justificationBuilder = new StringBuilder();
         boolean escaped = false;
@@ -298,7 +300,7 @@ public final class SonarResolve {
             escaped = false;
           } else if (current == '\\') {
             escaped = true;
-          } else if (current == '"') {
+          } else if (current == closingDelimiter) {
             justification = justificationBuilder.toString();
             return true;
           } else {
@@ -337,6 +339,25 @@ public final class SonarResolve {
 
       private static boolean isRuleKeyChar(char character) {
         return Character.isLetterOrDigit(character) || character == ':' || character == '_';
+      }
+
+      private static Character closingDelimiterFor(char openingDelimiter) {
+        switch (openingDelimiter) {
+          case '`':
+            return '`';
+          case '\'':
+            return '\'';
+          case '"':
+            return '"';
+          case '(':
+            return ')';
+          case '[':
+            return ']';
+          case '{':
+            return '}';
+          default:
+            return null;
+        }
       }
 
       private final class Cursor {
@@ -382,6 +403,10 @@ public final class SonarResolve {
             return true;
           }
           return false;
+        }
+
+        private char peek() {
+          return text.charAt(index);
         }
 
         private char consume() {

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
@@ -165,15 +165,15 @@ class SonarResolveTest {
       arguments(
         "SONAR-RESOLVE cpp:S100 \"line comment\"",
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
       arguments(
         "Sonar-Resolve [FP] cpp:S100 \"line comment\"",
         42,
-        new SonarResolve(42, IssueResolution.Status.FALSE_POSITIVE, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+        new SonarResolve(42, 42, IssueResolution.Status.FALSE_POSITIVE, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
       arguments(
         "sOnAr-ReSoLvE [AcCePt] cpp:S100 \"line comment\"",
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
       arguments(
         "sonar-resolve cpp:S100 \"line \\\"comment\\\"\"",
         42,

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
@@ -175,6 +175,30 @@ class SonarResolveTest {
         42,
         new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
       arguments(
+        "sonar-resolve cpp:S100 `line comment`",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
+        "sonar-resolve cpp:S100 'line \\'comment\\''",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line 'comment'")),
+      arguments(
+        "sonar-resolve cpp:S100 (line comment)",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
+        "sonar-resolve cpp:S100 [line \\]comment]",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line ]comment")),
+      arguments(
+        "sonar-resolve cpp:S100 [line comment)]",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment)")),
+      arguments(
+        "sonar-resolve cpp:S100 {line comment}",
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
         "sonar-resolve cpp:S100 \"line \\\"comment\\\"\"",
         42,
         new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line \"comment\"")),
@@ -206,7 +230,10 @@ class SonarResolveTest {
       arguments("sonar-resolve cpp:S100, cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: duplicate rule key 'cpp:S100'"),
       arguments("sonar-resolve cpp:S100, \"line comment\"", "Invalid sonar-resolve directive: invalid rule key list"),
       arguments("sonar-resolve cpp:S100", "Invalid sonar-resolve directive: missing justification"),
-      arguments("sonar-resolve cpp:S100 \"line comment", "Invalid sonar-resolve directive: unterminated justification"));
+      arguments("sonar-resolve cpp:S100 <line comment>", "Invalid sonar-resolve directive: missing justification"),
+      arguments("sonar-resolve cpp:S100 \"line comment", "Invalid sonar-resolve directive: unterminated justification"),
+      arguments("sonar-resolve cpp:S100 [line comment", "Invalid sonar-resolve directive: unterminated justification"),
+      arguments("sonar-resolve cpp:S100 {line comment", "Invalid sonar-resolve directive: unterminated justification"));
   }
 
   private static Stream<Arguments> multiLineSuccessCases() {
@@ -272,7 +299,21 @@ class SonarResolveTest {
           42,
           IssueResolution.Status.DEFAULT,
           Set.of(RuleKey.of("cpp", "S1234")),
-          "prefix\n\nmiddle\t\nsuffix\"")));
+          "prefix\n\nmiddle\t\nsuffix\"")),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S1234 [first line",
+          "second line]"
+        },
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first line\nsecond line")),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S1234 [first line)",
+          "second line]"
+        },
+        42,
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first line)\nsecond line")));
   }
 
   private static Stream<Arguments> multiLineFailureCases() {
@@ -304,6 +345,12 @@ class SonarResolveTest {
       arguments(
         new String[] {
           "sonar-resolve cpp:S100 \"reason",
+          "still reason"
+        },
+        "Invalid sonar-resolve directive: unterminated justification"),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S100 [reason",
           "still reason"
         },
         "Invalid sonar-resolve directive: unterminated justification"));

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
@@ -163,6 +163,18 @@ class SonarResolveTest {
           Set.of(RuleKey.of("cpp", "S100"), RuleKey.of("cpp", "M23_123")),
           "line comment")),
       arguments(
+        "SONAR-RESOLVE cpp:S100 \"line comment\"",
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
+        "Sonar-Resolve [FP] cpp:S100 \"line comment\"",
+        42,
+        new SonarResolve(42, IssueResolution.Status.FALSE_POSITIVE, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
+        "sOnAr-ReSoLvE [AcCePt] cpp:S100 \"line comment\"",
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
         "sonar-resolve cpp:S100 \"line \\\"comment\\\"\"",
         42,
         new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line \"comment\"")),
@@ -189,6 +201,7 @@ class SonarResolveTest {
       arguments("sonar-resolve \"line comment\"", "Invalid sonar-resolve directive: missing rule key"),
       arguments("sonar-resolve cppS1234 \"line comment\"", "Invalid sonar-resolve directive: invalid rule key 'cppS1234'"),
       arguments("sonar-resolve [accepted] cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: invalid status '[accepted]'"),
+      arguments("sonar-resolve [Accepted] cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: invalid status '[Accepted]'"),
       arguments("sonar-resolve [fp cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: unterminated status"),
       arguments("sonar-resolve cpp:S100, cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: duplicate rule key 'cpp:S100'"),
       arguments("sonar-resolve cpp:S100, \"line comment\"", "Invalid sonar-resolve directive: invalid rule key list"),
@@ -200,7 +213,7 @@ class SonarResolveTest {
     return Stream.of(
       arguments(
         new String[] {
-          "sonar-resolve",
+          "SONAR-RESOLVE",
           "cpp:S1234 \"reason\""
         },
         42,
@@ -222,8 +235,8 @@ class SonarResolveTest {
         new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first\nsecond\nthird")),
       arguments(
         new String[] {
-          "sonar-resolve",
-          "[fp]",
+          "Sonar-Resolve",
+          "[FP]",
           "cpp:S100,",
           "cpp:M23_123",
           "\"reason\""


### PR DESCRIPTION
This PR makes the shared `SonarResolve` parser case-insensitive.

It is consumed by https://github.com/SonarSource/sonar-cpp/pull/6121. This change aligns the implementation with the expected behavior for `sonar-resolve` directives by accepting case-insensitive forms of the directive keyword and status values, to make the feature easier to use.