### PR TITLE
CPP-7902 Support multiple justification delimiters in SonarResolve

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
@@ -285,9 +285,11 @@ public final class SonarResolve {
         if (cursor.isAtEnd()) {
           return incomplete("missing justification");
         }
-        if (!cursor.consume('"')) {
+        Character closingDelimiter = closingDelimiterFor(cursor.peek());
+        if (closingDelimiter == null) {
           return invalid("missing justification");
         }
+        cursor.consume();
 
         StringBuilder justificationBuilder = new StringBuilder();
         boolean escaped = false;
@@ -298,7 +300,7 @@ public final class SonarResolve {
             escaped = false;
           } else if (current == '\\') {
             escaped = true;
-          } else if (current == '"') {
+          } else if (current == closingDelimiter) {
             justification = justificationBuilder.toString();
             return true;
           } else {
@@ -337,6 +339,25 @@ public final class SonarResolve {
 
       private static boolean isRuleKeyChar(char character) {
         return Character.isLetterOrDigit(character) || character == ':' || character == '_';
+      }
+
+      private static Character closingDelimiterFor(char openingDelimiter) {
+        switch (openingDelimiter) {
+          case '`':
+            return '`';
+          case '\'':
+            return '\'';
+          case '"':
+            return '"';
+          case '(':
+            return ')';
+          case '[':
+            return ']';
+          case '{':
+            return '}';
+          default:
+            return null;
+        }
       }
 
       private final class Cursor {
@@ -382,6 +403,10 @@ public final class SonarResolve {
             return true;
           }
           return false;
+        }
+
+        private char peek() {
+          return text.charAt(index);
         }
 
         private char consume() {

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
@@ -177,27 +177,27 @@ class SonarResolveTest {
       arguments(
         "sonar-resolve cpp:S100 `line comment`",
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
       arguments(
         "sonar-resolve cpp:S100 'line \\'comment\\''",
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line 'comment'")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line 'comment'")),
       arguments(
         "sonar-resolve cpp:S100 (line comment)",
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
       arguments(
         "sonar-resolve cpp:S100 [line \\]comment]",
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line ]comment")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line ]comment")),
       arguments(
         "sonar-resolve cpp:S100 [line comment)]",
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment)")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment)")),
       arguments(
         "sonar-resolve cpp:S100 {line comment}",
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
       arguments(
         "sonar-resolve cpp:S100 \"line \\\"comment\\\"\"",
         42,
@@ -306,14 +306,14 @@ class SonarResolveTest {
           "second line]"
         },
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first line\nsecond line")),
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first line\nsecond line")),
       arguments(
         new String[] {
           "sonar-resolve cpp:S1234 [first line)",
           "second line]"
         },
         42,
-        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first line)\nsecond line")));
+        new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first line)\nsecond line")));
   }
 
   private static Stream<Arguments> multiLineFailureCases() {

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
@@ -175,6 +175,30 @@ class SonarResolveTest {
         42,
         new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
       arguments(
+        "sonar-resolve cpp:S100 `line comment`",
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
+        "sonar-resolve cpp:S100 'line \\'comment\\''",
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line 'comment'")),
+      arguments(
+        "sonar-resolve cpp:S100 (line comment)",
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
+        "sonar-resolve cpp:S100 [line \\]comment]",
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line ]comment")),
+      arguments(
+        "sonar-resolve cpp:S100 [line comment)]",
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment)")),
+      arguments(
+        "sonar-resolve cpp:S100 {line comment}",
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line comment")),
+      arguments(
         "sonar-resolve cpp:S100 \"line \\\"comment\\\"\"",
         42,
         new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S100")), "line \"comment\"")),
@@ -206,7 +230,10 @@ class SonarResolveTest {
       arguments("sonar-resolve cpp:S100, cpp:S100 \"line comment\"", "Invalid sonar-resolve directive: duplicate rule key 'cpp:S100'"),
       arguments("sonar-resolve cpp:S100, \"line comment\"", "Invalid sonar-resolve directive: invalid rule key list"),
       arguments("sonar-resolve cpp:S100", "Invalid sonar-resolve directive: missing justification"),
-      arguments("sonar-resolve cpp:S100 \"line comment", "Invalid sonar-resolve directive: unterminated justification"));
+      arguments("sonar-resolve cpp:S100 <line comment>", "Invalid sonar-resolve directive: missing justification"),
+      arguments("sonar-resolve cpp:S100 \"line comment", "Invalid sonar-resolve directive: unterminated justification"),
+      arguments("sonar-resolve cpp:S100 [line comment", "Invalid sonar-resolve directive: unterminated justification"),
+      arguments("sonar-resolve cpp:S100 {line comment", "Invalid sonar-resolve directive: unterminated justification"));
   }
 
   private static Stream<Arguments> multiLineSuccessCases() {
@@ -272,7 +299,21 @@ class SonarResolveTest {
           42,
           IssueResolution.Status.DEFAULT,
           Set.of(RuleKey.of("cpp", "S1234")),
-          "prefix\n\nmiddle\t\nsuffix\"")));
+          "prefix\n\nmiddle\t\nsuffix\"")),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S1234 [first line",
+          "second line]"
+        },
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first line\nsecond line")),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S1234 [first line)",
+          "second line]"
+        },
+        42,
+        new SonarResolve(42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("cpp", "S1234")), "first line)\nsecond line")));
   }
 
   private static Stream<Arguments> multiLineFailureCases() {
@@ -304,6 +345,12 @@ class SonarResolveTest {
       arguments(
         new String[] {
           "sonar-resolve cpp:S100 \"reason",
+          "still reason"
+        },
+        "Invalid sonar-resolve directive: unterminated justification"),
+      arguments(
+        new String[] {
+          "sonar-resolve cpp:S100 [reason",
           "still reason"
         },
         "Invalid sonar-resolve directive: unterminated justification"));


### PR DESCRIPTION
This PR adds support for multiple justification delimiters in the shared `SonarResolve` parser.

It is consumed by https://github.com/SonarSource/sonar-cpp/pull/6122. This change allows different delimiters so that each language can work with the most suitable one when writing `sonar-resolve` directives.