### PR TITLE
Allow dashes in `sonar-resolve` rule keys

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/SonarResolve.java
@@ -338,7 +338,7 @@ public final class SonarResolve {
       }
 
       private static boolean isRuleKeyChar(char character) {
-        return Character.isLetterOrDigit(character) || character == ':' || character == '_';
+        return Character.isLetterOrDigit(character) || character == ':' || character == '_' || character == '-';
       }
 
       private static Character closingDelimiterFor(char openingDelimiter) {

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/SonarResolveTest.java
@@ -214,7 +214,12 @@ class SonarResolveTest {
           42,
           IssueResolution.Status.DEFAULT,
           Set.of(RuleKey.of("cpp", "S100")),
-          "line\nline\rline\tline\\line")));
+          "line\nline\rline\tline\\line")),
+        arguments(
+            "sonar-resolve community-foo:S100 \"line comment\"",
+            42,
+            new SonarResolve(42, 42, IssueResolution.Status.DEFAULT, Set.of(RuleKey.of("community-foo", "S100")), "line comment"))
+    );
   }
 
   private static Stream<Arguments> singleLineFailureCases() {


### PR DESCRIPTION
This PR enables the `sonar-resolve` parser to recognize rule keys containing dashes.

The existing implementation only allows letters, digits, colons, and underscores. This blocks plugins like SonarDelphi (which has repository key `community-delphi`) from implementing support for `sonar-resolve`.

See: https://github.com/integrated-application-development/sonar-delphi/issues/432.