### PR TITLE
APPSEC-3389: Expose getCleartextProtocols() and getAlternativeProtocols() in CleartextProtocolFilter

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -19,8 +19,10 @@ package org.sonarsource.analyzer.commons.appsec;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Determines whether a cleartext-protocol URL should be considered safe and should not
@@ -128,9 +130,35 @@ public final class CleartextProtocolFilter {
     "\\.(?:example|test|localhost)" +
     ")(?=:|$)", Pattern.CASE_INSENSITIVE);
 
-  private static final Set<String> CLEARTEXT_SCHEMES = Set.of(
-    "http", "ftp", "ws", "telnet", "rtmp", "tftp", "gopher", "irc",
-    "smtp", "ldap", "amqp", "mqtt", "imap", "pop3", "nntp", "sip", "stomp");
+  /**
+   * Maps each cleartext scheme name to its recommended secure alternative.
+   * This is the single source of truth for both detection and messaging.
+   */
+  private static final Map<String, String> CLEARTEXT_PROTOCOL_ALTERNATIVES = Map.ofEntries(
+    Map.entry("http",    "https"),
+    Map.entry("ftp",     "sftp, scp or ftps"),
+    Map.entry("ws",      "wss"),
+    Map.entry("telnet",  "ssh"),
+    Map.entry("gopher",  "https"),
+    Map.entry("tftp",    "sftp"),
+    Map.entry("smtp",    "smtps"),
+    Map.entry("ldap",    "ldaps"),
+    Map.entry("imap",    "imaps"),
+    Map.entry("pop3",    "pop3s"),
+    Map.entry("amqp",    "amqps"),
+    Map.entry("mqtt",    "mqtts"),
+    Map.entry("sip",     "sips"),
+    Map.entry("rtmp",    "rtmps"),
+    Map.entry("irc",     "ircs"),
+    Map.entry("nntp",    "nntps"),
+    Map.entry("stomp",   "stomps")
+  );
+
+  private static final Set<String> CLEARTEXT_SCHEMES = CLEARTEXT_PROTOCOL_ALTERNATIVES.keySet();
+
+  private static final Set<String> CLEARTEXT_SCHEME_PREFIXES = CLEARTEXT_SCHEMES.stream()
+    .map(s -> s + "://")
+    .collect(Collectors.toUnmodifiableSet());
 
   // Lenient fallback: extracts the authority from a cleartext URL without strict URI validation.
   // Used when java.net.URI rejects the string (e.g. template placeholders) or returns a null
@@ -139,6 +167,26 @@ public final class CleartextProtocolFilter {
     "^(?:" + String.join("|", CLEARTEXT_SCHEMES) + ")://(?:[^@\\s/?#]++@)?(?<rest>[^\\s/?#]++)", Pattern.CASE_INSENSITIVE);
 
   private CleartextProtocolFilter() {
+  }
+
+  /**
+   * Returns the set of cleartext scheme strings (including the {@code ://} suffix) for which
+   * a well-known secure alternative exists. These are the schemes that rule implementations
+   * should flag, e.g. {@code {"http://", "ftp://", "ws://", ...}}.
+   *
+   * <p>Use in conjunction with {@link #getAlternativeProtocols()} to build issue messages.
+   */
+  public static Set<String> getCleartextProtocols() {
+    return CLEARTEXT_SCHEME_PREFIXES;
+  }
+
+  /**
+   * Returns an unmodifiable map from each reportable cleartext scheme name (without {@code ://})
+   * to the human-readable secure alternative recommended in issue messages, e.g.
+   * {@code {"http" -> "https", "ftp" -> "sftp, scp or ftps", ...}}.
+   */
+  public static Map<String, String> getAlternativeProtocols() {
+    return CLEARTEXT_PROTOCOL_ALTERNATIVES;
   }
 
   /**

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -32,8 +32,10 @@ import java.util.stream.Collectors;
  * trigger a security warning.
  * <p>
  * Recognised cleartext schemes: {@code http}, {@code ftp}, {@code ws}, {@code telnet},
- * {@code rtmp}, {@code tftp}, {@code gopher}, {@code irc}. Any other scheme is considered
- * safe (e.g. {@code https}, {@code wss}, {@code sftp}).
+ * {@code rtmp}, {@code tftp}, {@code gopher}, {@code irc}, {@code smtp}, {@code ldap},
+ * {@code amqp}, {@code mqtt}, {@code imap}, {@code pop3}, {@code nntp}, {@code sip},
+ * {@code stomp}. Any other scheme is considered safe (e.g. {@code https}, {@code wss},
+ * {@code sftp}).
  * <p>
  * Three categories of safe cleartext URLs are recognised:
  * <ul>
@@ -183,6 +185,8 @@ public final class CleartextProtocolFilter {
    * should flag, e.g. {@code {"http://", "ftp://", "ws://", ...}}.
    *
    * <p>Use in conjunction with {@link #getIssueMessage(String)} to build issue messages.
+   * Note: strip the {@code ://} suffix before passing a value from this set to
+   * {@link #getIssueMessage(String)}.
    */
   public static Set<String> getCleartextProtocols() {
     return CLEARTEXT_SCHEME_PREFIXES;
@@ -191,7 +195,7 @@ public final class CleartextProtocolFilter {
   /**
    * Returns the standard issue message for the given cleartext scheme name (without {@code ://}),
    * e.g. {@code getIssueMessage("http")} returns
-   * {@code Optional.of("Using http protocol is insecure. Use https instead.")}.
+   * {@code Optional.of("Using HTTP protocol is insecure. Use HTTPS instead.")}.
    * Returns {@link Optional#empty()} if the scheme is not a known cleartext protocol.
    *
    * @param scheme the scheme name as it appears in the URL, without {@code ://}

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -174,19 +175,26 @@ public final class CleartextProtocolFilter {
    * a well-known secure alternative exists. These are the schemes that rule implementations
    * should flag, e.g. {@code {"http://", "ftp://", "ws://", ...}}.
    *
-   * <p>Use in conjunction with {@link #getAlternativeProtocols()} to build issue messages.
+   * <p>Use in conjunction with {@link #getIssueMessage(String)} to build issue messages.
    */
   public static Set<String> getCleartextProtocols() {
     return CLEARTEXT_SCHEME_PREFIXES;
   }
 
   /**
-   * Returns an unmodifiable map from each reportable cleartext scheme name (without {@code ://})
-   * to the human-readable secure alternative recommended in issue messages, e.g.
-   * {@code {"http" -> "https", "ftp" -> "sftp, scp or ftps", ...}}.
+   * Returns the standard issue message for the given cleartext scheme name (without {@code ://}),
+   * e.g. {@code getIssueMessage("http")} returns
+   * {@code Optional.of("Using http protocol is insecure. Use https instead.")}.
+   * Returns {@link Optional#empty()} if the scheme is not a known cleartext protocol.
+   *
+   * @param scheme the scheme name as it appears in the URL, without {@code ://}
    */
-  public static Map<String, String> getAlternativeProtocols() {
-    return CLEARTEXT_PROTOCOL_ALTERNATIVES;
+  public static Optional<String> getIssueMessage(String scheme) {
+    String alternative = CLEARTEXT_PROTOCOL_ALTERNATIVES.get(scheme);
+    if (alternative == null) {
+      return Optional.empty();
+    }
+    return Optional.of("Using " + scheme + " protocol is insecure. Use " + alternative + " instead.");
   }
 
   /**

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -18,10 +18,12 @@ package org.sonarsource.analyzer.commons.appsec;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -132,33 +134,38 @@ public final class CleartextProtocolFilter {
     ")(?=:|$)", Pattern.CASE_INSENSITIVE);
 
   /**
-   * Maps each cleartext scheme name to its recommended secure alternative.
+   * Maps each cleartext scheme name (correctly capitalised) to its recommended secure alternative.
+   * Keys use display-correct capitalisation (acronyms in ALL-CAPS, proper names in Title Case).
+   * The map uses case-insensitive ordering so lookups work regardless of the input case.
    * This is the single source of truth for both detection and messaging.
    */
-  private static final Map<String, String> CLEARTEXT_PROTOCOL_ALTERNATIVES = Map.ofEntries(
-    Map.entry("http",    "https"),
-    Map.entry("ftp",     "sftp, scp or ftps"),
-    Map.entry("ws",      "wss"),
-    Map.entry("telnet",  "ssh"),
-    Map.entry("gopher",  "https"),
-    Map.entry("tftp",    "sftp"),
-    Map.entry("smtp",    "smtps"),
-    Map.entry("ldap",    "ldaps"),
-    Map.entry("imap",    "imaps"),
-    Map.entry("pop3",    "pop3s"),
-    Map.entry("amqp",    "amqps"),
-    Map.entry("mqtt",    "mqtts"),
-    Map.entry("sip",     "sips"),
-    Map.entry("rtmp",    "rtmps"),
-    Map.entry("irc",     "ircs"),
-    Map.entry("nntp",    "nntps"),
-    Map.entry("stomp",   "stomps")
-  );
+  private static final Map<String, String> CLEARTEXT_PROTOCOL_ALTERNATIVES;
+  static {
+    TreeMap<String, String> m = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    m.put("HTTP",    "HTTPS");
+    m.put("FTP",     "SFTP, SCP or FTPS");
+    m.put("WS",      "WSS");
+    m.put("Telnet",  "SSH");
+    m.put("Gopher",  "HTTPS");
+    m.put("TFTP",    "SFTP");
+    m.put("SMTP",    "SMTPS");
+    m.put("LDAP",    "LDAPS");
+    m.put("IMAP",    "IMAPS");
+    m.put("POP3",    "POP3S");
+    m.put("AMQP",    "AMQPS");
+    m.put("MQTT",    "MQTTS");
+    m.put("SIP",     "SIPS");
+    m.put("RTMP",    "RTMPS");
+    m.put("IRC",     "IRCS");
+    m.put("NNTP",    "NNTPS");
+    m.put("STOMP",   "STOMPS");
+    CLEARTEXT_PROTOCOL_ALTERNATIVES = Collections.unmodifiableMap(m);
+  }
 
   private static final Set<String> CLEARTEXT_SCHEMES = CLEARTEXT_PROTOCOL_ALTERNATIVES.keySet();
 
   private static final Set<String> CLEARTEXT_SCHEME_PREFIXES = CLEARTEXT_SCHEMES.stream()
-    .map(s -> s + "://")
+    .map(s -> s.toLowerCase(Locale.ROOT) + "://")
     .collect(Collectors.toUnmodifiableSet());
 
   // Lenient fallback: extracts the authority from a cleartext URL without strict URI validation.
@@ -190,11 +197,10 @@ public final class CleartextProtocolFilter {
    * @param scheme the scheme name as it appears in the URL, without {@code ://}
    */
   public static Optional<String> getIssueMessage(String scheme) {
-    String alternative = CLEARTEXT_PROTOCOL_ALTERNATIVES.get(scheme);
-    if (alternative == null) {
-      return Optional.empty();
-    }
-    return Optional.of("Using " + scheme + " protocol is insecure. Use " + alternative + " instead.");
+    return CLEARTEXT_PROTOCOL_ALTERNATIVES.entrySet().stream()
+      .filter(e -> e.getKey().equalsIgnoreCase(scheme))
+      .findFirst()
+      .map(e -> "Using " + e.getKey() + " protocol is insecure. Use " + e.getValue() + " instead.");
   }
 
   /**
@@ -229,7 +235,7 @@ public final class CleartextProtocolFilter {
    */
   public static boolean isSafeWithoutTls(URI url) {
     var scheme = url.getScheme();
-    if (scheme == null || !CLEARTEXT_SCHEMES.contains(scheme.toLowerCase(Locale.ROOT))) {
+    if (scheme == null || !CLEARTEXT_SCHEMES.contains(scheme)) {
       return true;
     }
     var host = url.getHost();

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -28,42 +28,10 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 class CleartextProtocolFilterTest {
 
   @Test
-  void getCleartextProtocolsReturnsExpectedSet() {
-    assertThat(CleartextProtocolFilter.getCleartextProtocols())
-      .containsExactlyInAnyOrder(
-        "http://", "ftp://", "ws://", "telnet://", "gopher://", "tftp://",
-        "smtp://", "ldap://", "imap://", "pop3://", "amqp://", "mqtt://",
-        "sip://", "rtmp://", "irc://", "nntp://", "stomp://");
-  }
-
-  @Test
   void getCleartextProtocolsIsUnmodifiable() {
     var protocols = CleartextProtocolFilter.getCleartextProtocols();
     assertThatExceptionOfType(UnsupportedOperationException.class)
       .isThrownBy(() -> protocols.add("custom://"));
-  }
-
-  @Test
-  void getAlternativeProtocolsReturnsExpectedMappings() {
-    var alternatives = CleartextProtocolFilter.getAlternativeProtocols();
-    assertThat(alternatives)
-      .containsEntry("http",   "https")
-      .containsEntry("ftp",    "sftp, scp or ftps")
-      .containsEntry("ws",     "wss")
-      .containsEntry("telnet", "ssh")
-      .containsEntry("gopher", "https")
-      .containsEntry("tftp",   "sftp")
-      .containsEntry("smtp",   "smtps")
-      .containsEntry("ldap",   "ldaps")
-      .containsEntry("imap",   "imaps")
-      .containsEntry("pop3",   "pop3s")
-      .containsEntry("amqp",   "amqps")
-      .containsEntry("mqtt",   "mqtts")
-      .containsEntry("sip",    "sips")
-      .containsEntry("rtmp",   "rtmps")
-      .containsEntry("irc",    "ircs")
-      .containsEntry("nntp",   "nntps")
-      .containsEntry("stomp",  "stomps");
   }
 
   @Test

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -37,11 +37,13 @@ class CleartextProtocolFilterTest {
   @Test
   void getIssueMessageReturnsFormattedMessage() {
     assertThat(CleartextProtocolFilter.getIssueMessage("http"))
-      .hasValue("Using http protocol is insecure. Use https instead.");
+      .hasValue("Using HTTP protocol is insecure. Use HTTPS instead.");
     assertThat(CleartextProtocolFilter.getIssueMessage("ftp"))
-      .hasValue("Using ftp protocol is insecure. Use sftp, scp or ftps instead.");
+      .hasValue("Using FTP protocol is insecure. Use SFTP, SCP or FTPS instead.");
     assertThat(CleartextProtocolFilter.getIssueMessage("telnet"))
-      .hasValue("Using telnet protocol is insecure. Use ssh instead.");
+      .hasValue("Using Telnet protocol is insecure. Use SSH instead.");
+    assertThat(CleartextProtocolFilter.getIssueMessage("gopher"))
+      .hasValue("Using Gopher protocol is insecure. Use HTTPS instead.");
   }
 
   @Test

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -38,8 +38,9 @@ class CleartextProtocolFilterTest {
 
   @Test
   void getCleartextProtocolsIsUnmodifiable() {
+    var protocols = CleartextProtocolFilter.getCleartextProtocols();
     assertThatExceptionOfType(UnsupportedOperationException.class)
-      .isThrownBy(() -> CleartextProtocolFilter.getCleartextProtocols().add("custom://"));
+      .isThrownBy(() -> protocols.add("custom://"));
   }
 
   @Test
@@ -67,8 +68,9 @@ class CleartextProtocolFilterTest {
 
   @Test
   void getAlternativeProtocolsIsUnmodifiable() {
+    var alternatives = CleartextProtocolFilter.getAlternativeProtocols();
     assertThatExceptionOfType(UnsupportedOperationException.class)
-      .isThrownBy(() -> CleartextProtocolFilter.getAlternativeProtocols().put("custom", "customs"));
+      .isThrownBy(() -> alternatives.put("custom", "customs"));
   }
 
   @Test

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -18,12 +18,68 @@ package org.sonarsource.analyzer.commons.appsec;
 
 import java.net.URI;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class CleartextProtocolFilterTest {
+
+  @Test
+  void getCleartextProtocolsReturnsExpectedSet() {
+    assertThat(CleartextProtocolFilter.getCleartextProtocols())
+      .containsExactlyInAnyOrder(
+        "http://", "ftp://", "ws://", "telnet://", "gopher://", "tftp://",
+        "smtp://", "ldap://", "imap://", "pop3://", "amqp://", "mqtt://",
+        "sip://", "rtmp://", "irc://", "nntp://", "stomp://");
+  }
+
+  @Test
+  void getCleartextProtocolsIsUnmodifiable() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> CleartextProtocolFilter.getCleartextProtocols().add("custom://"));
+  }
+
+  @Test
+  void getAlternativeProtocolsReturnsExpectedMappings() {
+    var alternatives = CleartextProtocolFilter.getAlternativeProtocols();
+    assertThat(alternatives)
+      .containsEntry("http",   "https")
+      .containsEntry("ftp",    "sftp, scp or ftps")
+      .containsEntry("ws",     "wss")
+      .containsEntry("telnet", "ssh")
+      .containsEntry("gopher", "https")
+      .containsEntry("tftp",   "sftp")
+      .containsEntry("smtp",   "smtps")
+      .containsEntry("ldap",   "ldaps")
+      .containsEntry("imap",   "imaps")
+      .containsEntry("pop3",   "pop3s")
+      .containsEntry("amqp",   "amqps")
+      .containsEntry("mqtt",   "mqtts")
+      .containsEntry("sip",    "sips")
+      .containsEntry("rtmp",   "rtmps")
+      .containsEntry("irc",    "ircs")
+      .containsEntry("nntp",   "nntps")
+      .containsEntry("stomp",  "stomps");
+  }
+
+  @Test
+  void getAlternativeProtocolsIsUnmodifiable() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> CleartextProtocolFilter.getAlternativeProtocols().put("custom", "customs"));
+  }
+
+  @Test
+  void cleartextProtocolKeysMatchAlternativeProtocolKeys() {
+    var protocols = CleartextProtocolFilter.getCleartextProtocols();
+    var alternativeKeys = CleartextProtocolFilter.getAlternativeProtocols().keySet();
+    assertThat(protocols)
+      .as("getCleartextProtocols() must be exactly the keySet of getAlternativeProtocols() with :// appended")
+      .hasSameSizeAs(alternativeKeys)
+      .allSatisfy(p -> assertThat(alternativeKeys).contains(p.replace("://", "")));
+  }
 
   @ParameterizedTest(name = "[{index}] {0}")
   @MethodSource("safeUrls")

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -35,20 +35,27 @@ class CleartextProtocolFilterTest {
   }
 
   @Test
-  void getAlternativeProtocolsIsUnmodifiable() {
-    var alternatives = CleartextProtocolFilter.getAlternativeProtocols();
-    assertThatExceptionOfType(UnsupportedOperationException.class)
-      .isThrownBy(() -> alternatives.put("custom", "customs"));
+  void getIssueMessageReturnsFormattedMessage() {
+    assertThat(CleartextProtocolFilter.getIssueMessage("http"))
+      .hasValue("Using http protocol is insecure. Use https instead.");
+    assertThat(CleartextProtocolFilter.getIssueMessage("ftp"))
+      .hasValue("Using ftp protocol is insecure. Use sftp, scp or ftps instead.");
+    assertThat(CleartextProtocolFilter.getIssueMessage("telnet"))
+      .hasValue("Using telnet protocol is insecure. Use ssh instead.");
   }
 
   @Test
-  void cleartextProtocolKeysMatchAlternativeProtocolKeys() {
-    var protocols = CleartextProtocolFilter.getCleartextProtocols();
-    var alternativeKeys = CleartextProtocolFilter.getAlternativeProtocols().keySet();
-    assertThat(protocols)
-      .as("getCleartextProtocols() must be exactly the keySet of getAlternativeProtocols() with :// appended")
-      .hasSameSizeAs(alternativeKeys)
-      .allSatisfy(p -> assertThat(alternativeKeys).contains(p.replace("://", "")));
+  void getIssueMessageReturnsEmptyForUnknownScheme() {
+    assertThat(CleartextProtocolFilter.getIssueMessage("https")).isEmpty();
+    assertThat(CleartextProtocolFilter.getIssueMessage("unknown")).isEmpty();
+  }
+
+  @Test
+  void getIssueMessageIsPresentForAllCleartextProtocols() {
+    CleartextProtocolFilter.getCleartextProtocols()
+      .forEach(prefix -> assertThat(CleartextProtocolFilter.getIssueMessage(prefix.replace("://", "")))
+        .as("missing issue message for scheme: %s", prefix)
+        .isPresent());
   }
 
   @ParameterizedTest(name = "[{index}] {0}")


### PR DESCRIPTION
## Summary

- Adds `getCleartextProtocols()` returning the set of cleartext scheme prefixes with `://` (e.g. `{"http://", "ftp://", ...}`) for use in startsWith-style detection
- Adds `getAlternativeProtocols()` returning a map of scheme name → secure alternative (e.g. `{"http" → "https", ...}`) for use in issue messages
- `CLEARTEXT_PROTOCOL_ALTERNATIVES` is now the single source of truth; `CLEARTEXT_SCHEMES` is derived from its keySet to eliminate duplication

## Test plan

- [ ] `getCleartextProtocolsReturnsExpectedSet` — verifies all 17 scheme prefixes are present
- [ ] `getCleartextProtocolsIsUnmodifiable` — returned set rejects mutation
- [ ] `getAlternativeProtocolsReturnsExpectedMappings` — verifies all 17 scheme → alternative entries
- [ ] `getAlternativeProtocolsIsUnmodifiable` — returned map rejects mutation
- [ ] `cleartextProtocolKeysMatchAlternativeProtocolKeys` — consistency check between the two accessors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Refactored protocol data:**
  - Replaced the hardcoded `CLEARTEXT_SCHEMES` set with `CLEARTEXT_PROTOCOL_ALTERNATIVES` map to act as the single source of truth.
  - Added `getIssueMessage(String scheme)` to dynamically generate standardized security warnings.
- **Improved internal logic:**
  - Updated `isSafeWithoutTls` to leverage the new case-insensitive map lookups.
  - Derived `CLEARTEXT_SCHEME_PREFIXES` automatically from the map keys to ensure consistency.
- **Testing enhancements:**
  - Added comprehensive tests for `getIssueMessage` and ensured immutability of exposed collections.
  - Verified all supported protocols have associated security messages.


<sub>This will update automatically on new commits.</sub>