### PR TITLE
APPSEC-3388: Add missing namespace URI authorities, fix bare-scheme bug, widen IPv4 loopback

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -196,11 +196,6 @@ public final class CleartextProtocolFilter {
   private static final Pattern CLEARTEXT_AUTHORITY = Pattern.compile(
     "^(?:" + String.join("|", CLEARTEXT_SCHEMES) + ")://(?:[^@\\s/?#]++@)?(?<rest>[^\\s/?#]++)", Pattern.CASE_INSENSITIVE);
 
-  // Matches a bare cleartext scheme prefix (e.g. "http://") with no authority following it.
-  // Used to detect bare-scheme strings that CLEARTEXT_AUTHORITY won't match.
-  private static final Pattern CLEARTEXT_SCHEME_PREFIX = Pattern.compile(
-    "^(?:" + String.join("|", CLEARTEXT_SCHEMES) + ")://", Pattern.CASE_INSENSITIVE);
-
   private CleartextProtocolFilter() {
   }
 
@@ -253,7 +248,7 @@ public final class CleartextProtocolFilter {
       // fall through to lenient parsing
     }
     var matcher = CLEARTEXT_AUTHORITY.matcher(stripped);
-    return matcher.find() ? isSafeHost(matcher.group("rest")) : !CLEARTEXT_SCHEME_PREFIX.matcher(stripped).find();
+    return matcher.find() ? isSafeHost(matcher.group("rest")) : CLEARTEXT_SCHEME_PREFIXES.stream().noneMatch(p -> stripped.toLowerCase(Locale.ROOT).startsWith(p));
   }
 
   /**

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -64,8 +64,8 @@ public final class CleartextProtocolFilter {
   private static final Pattern SAFE_HOSTS = Pattern.compile("(?:" +
     // localhost
     "^localhost|" +
-    // IPv4 loopback (127.0.0.0/8)
-    "^127(?:\\.\\d+){3}|" +
+    // IPv4 loopback (127.0.0.0/8) — 2–4 octet forms (127.1, 127.0.1, 127.0.0.1)
+    "^127(?:\\.\\d+){1,3}|" +
     // IPv6 loopback (::1)
     "^\\[(?:0*:){7}:?0*1\\]|^\\[::1\\]|" +
     // IPv4 link-local (169.254.0.0/16, RFC 3927) — AWS/Azure/GCP/OCI IMDS
@@ -122,7 +122,27 @@ public final class CleartextProtocolFilter {
     // Dublin Core legacy URIs
     "^dublincore\\.org|" +
     // Open Graph Protocol
-    "^ogp\\.me" +
+    "^ogp\\.me|" +
+    // Apache Cocoon / XML project namespaces
+    "^xml\\.apache\\.org|" +
+    // Office Open XML (OOXML) — PhpSpreadsheet, PHPWord, etc.
+    "^schemas\\.openxmlformats\\.org|" +
+    // RDF Schema
+    "^rdfs\\.org|" +
+    // Google XML schemas
+    "^schemas\\.google\\.com|" +
+    // Amazon OpenSearch namespace
+    "^a9\\.com|" +
+    // Adobe namespaces
+    "^ns\\.adobe\\.com|" +
+    // IEEE Learning Technology Standards
+    "^ltsc\\.ieee\\.org|" +
+    // DocBook XML
+    "^docbook\\.org|" +
+    // GraphML
+    "^graphml\\.graphdrawing\\.org|" +
+    // JSON Schema
+    "^json-schema\\.org" +
     ")(?=:|$)", Pattern.CASE_INSENSITIVE);
 
   // --- IANA-reserved documentation / placeholder domains --------------------------------
@@ -176,6 +196,11 @@ public final class CleartextProtocolFilter {
   private static final Pattern CLEARTEXT_AUTHORITY = Pattern.compile(
     "^(?:" + String.join("|", CLEARTEXT_SCHEMES) + ")://(?:[^@\\s/?#]++@)?(?<rest>[^\\s/?#]++)", Pattern.CASE_INSENSITIVE);
 
+  // Matches a bare cleartext scheme prefix (e.g. "http://") with no authority following it.
+  // Used to detect bare-scheme strings that CLEARTEXT_AUTHORITY won't match.
+  private static final Pattern CLEARTEXT_SCHEME_PREFIX = Pattern.compile(
+    "^(?:" + String.join("|", CLEARTEXT_SCHEMES) + ")://", Pattern.CASE_INSENSITIVE);
+
   private CleartextProtocolFilter() {
   }
 
@@ -228,7 +253,7 @@ public final class CleartextProtocolFilter {
       // fall through to lenient parsing
     }
     var matcher = CLEARTEXT_AUTHORITY.matcher(stripped);
-    return !matcher.find() || isSafeHost(matcher.group("rest"));
+    return matcher.find() ? isSafeHost(matcher.group("rest")) : !CLEARTEXT_SCHEME_PREFIX.matcher(stripped).find();
   }
 
   /**

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -248,7 +248,11 @@ public final class CleartextProtocolFilter {
       // fall through to lenient parsing
     }
     var matcher = CLEARTEXT_AUTHORITY.matcher(stripped);
-    return matcher.find() ? isSafeHost(matcher.group("rest")) : CLEARTEXT_SCHEME_PREFIXES.stream().noneMatch(p -> stripped.toLowerCase(Locale.ROOT).startsWith(p));
+    if (matcher.find()) {
+      return isSafeHost(matcher.group("rest"));
+    }
+    var lower = stripped.toLowerCase(Locale.ROOT);
+    return CLEARTEXT_SCHEME_PREFIXES.stream().noneMatch(lower::startsWith);
   }
 
   /**

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -150,6 +150,11 @@ class CleartextProtocolFilterTest {
       "http://myapp.localhost",
       "http://service.myapp.localhost:8080",
 
+      // IPv4 loopback — short-form (2- and 3-octet) addresses
+      "http://127.1",
+      "http://127.0.1",
+      "http://127.1:8080/api",
+
       // New cleartext schemes — safe because of internal/documentation host
       "ws://localhost",
       "ws://example.com",
@@ -190,6 +195,18 @@ class CleartextProtocolFilterTest {
       // Underscores in hostnames — URI.getHost() returns null, lenient fallback used
       "http://my_service.svc.cluster.local:8200",
       "http://my_app.example.com/path",
+
+      // New namespace URI authorities
+      "http://xml.apache.org/xslt",
+      "http://schemas.openxmlformats.org/drawingml/2006/main",
+      "http://rdfs.org/ns/void#",
+      "http://schemas.google.com/g/2005",
+      "http://a9.com/-/spec/opensearch/1.1/",
+      "http://ns.adobe.com/xap/1.0/",
+      "http://ltsc.ieee.org/xsd/LOM",
+      "http://docbook.org/ns/docbook",
+      "http://graphml.graphdrawing.org/graphml",
+      "http://json-schema.org/draft-07/schema",
 
       // Case insensitivity and surrounding whitespace
       "HTTP://LOCALHOST:8080",
@@ -307,6 +324,11 @@ class CleartextProtocolFilterTest {
 
       // Surrounding whitespace with a non-safe URL
       "  http://acme.com  ",
+
+      // Bare cleartext scheme with no authority — must not be suppressed
+      "http://",
+      "ftp://",
+      "ws://",
 
       // Malformed — cannot be parsed as a URI (URISyntaxException → false)
       "http://foo bar.com",


### PR DESCRIPTION
## Summary

- Adds 10 missing namespace URI authorities to `NAMESPACE_URI_AUTHORITIES`: `xml.apache.org`, `schemas.openxmlformats.org`, `rdfs.org`, `schemas.google.com`, `a9.com`, `ns.adobe.com`, `ltsc.ieee.org`, `docbook.org`, `graphml.graphdrawing.org`, `json-schema.org`
- Fixes bare-scheme bug: `http://` was incorrectly returned as safe in the lenient fallback path when `CLEARTEXT_AUTHORITY` found no authority; a new `CLEARTEXT_SCHEME_PREFIX` pattern is used to distinguish "not a cleartext URL" from "cleartext URL with no host"
- Widens IPv4 loopback pattern from `{3}` to `{1,3}` to accept short-form addresses (`127.1`, `127.0.1`) that resolve to loopback on POSIX systems

## Test plan

- [ ] 10 new safe URL test cases for each added namespace URI authority
- [ ] `http://`, `ftp://`, `ws://` added to `notSafeUrls` — verify bare-scheme bug is fixed
- [ ] `http://127.1`, `http://127.0.1`, `http://127.1:8080` added to `safeUrls` — verify short-form loopback

🤖 Generated with [Claude Code](https://claude.com/claude-code)