### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -1,0 +1,53 @@
+name: Automated Release
+on:
+  workflow_dispatch:
+    inputs:
+      short-description:
+        description: "Short description for the REL ticket"
+        required: true
+        type: string
+      branch:
+        description: "Branch from which to do the release"
+        required: true
+        default: "master"
+        type: string
+      new-version:
+        description: "New version to release (without -SNAPSHOT; if left empty, the current minor version will be auto-incremented)"
+        required: false
+        type: string
+      verbose:
+        description: "Enable verbose logging"
+        type: boolean
+        default: false
+      dry-run:
+        description: "Test mode: uses Jira sandbox and creates draft GitHub release"
+        type: boolean
+        default: false
+
+jobs:
+  release:
+    name: Release
+    uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@v1
+    permissions:
+      statuses: read
+      id-token: write
+      contents: write
+      actions: write
+      pull-requests: write
+    with:
+      project-name: "sonar-analyzer-commons"
+      plugin-name: "analyzer-commons"
+      jira-project-key: "ACOMMONS"
+      rule-props-changed: false
+      short-description: ${{ github.event.inputs.short-description }}
+      new-version: ${{ github.event.inputs.new-version }}
+      sqc-integration: false
+      sqs-integration: false
+      branch: ${{ github.event.inputs.branch }}
+      pm-email: ""
+      slack-channel: "team-analysis-notifications"
+      verbose: ${{ github.event.inputs.verbose == 'true' }}
+      use-jira-sandbox: ${{ github.event.inputs.dry-run == 'true' }}
+      is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}
+      bump-version: true
+      bump-version-tool: maven

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,20 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: Version
+        required: true
+      releaseId:
+        type: string
+        description: Release ID
+        required: true
+      dryRun:
+        type: boolean
+        description: Flag to enable the dry-run execution
+        default: false
 
 jobs:
   release:
@@ -17,4 +31,7 @@ jobs:
       publishToBinaries: true
       mavenCentralSync: true
       slackChannel: team-analysis-notifications
+      version: ${{ inputs.version || github.event.release.tag_name }}
+      releaseId: ${{ inputs.releaseId || github.event.release.id }}
+      dryRun: ${{ inputs.dryRun == true }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     with:
       publishToBinaries: true
       mavenCentralSync: true
-      slackChannel: : squad-corelang-release
+      slackChannel: squad-corelang-release
       version: ${{ inputs.version || github.event.release.tag_name }}
       releaseId: ${{ inputs.releaseId || github.event.release.id }}
       dryRun: ${{ inputs.dryRun == true }}


### PR DESCRIPTION
## Summary
- Add `automated-release.yml`: drives the release via `release-github-actions` reusable workflow — no SQS/SQC/IDE integrations, Maven version bump built-in
- Update `release.yml`: add `workflow_dispatch` trigger with `version`/`releaseId`/`dryRun` inputs required for the automated release orchestration

## Notes
- No vault PR needed: the `release-automation` secret is only consumed when SQS/SQC integration is enabled
- No `bump-versions.yaml` needed: using the built-in `bump-version: true` + `bump-version-tool: maven` inputs

## Test plan
- [ ] Trigger with `dry-run: true` and verify Jira sandbox tickets + draft GitHub release
- [ ] Trigger with `dry-run: false` for a real release