### PR TITLE
CLP-21 Move repository ownership to Core Languages and Parsers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @SonarSource/quality-team
+.github/CODEOWNERS @SonarSource/code-quality-core-languages-parsers-squad


### PR DESCRIPTION
----
## Summary by Gitar

- **Code ownership:**
  - Update `CODEOWNERS` file to transfer repository ownership to the `code-quality-core-languages-parsers-squad` team.

<sub>This will update automatically on new commits.</sub>