### PR TITLE
ACOMMONS-60 Use squad Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,27 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>SonarSource/core-languages-tooling-public:renovate-config"
-  ],
-  "rebaseWhen": "conflicted",
-  "minimumReleaseAgeBehaviour": "timestamp-required",
-  "packageRules": [
-    {
-      "description": "Group GitHub Actions updates",
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions dependencies",
-      "groupSlug": "github-actions-dependencies"
-    },
-    {
-      "description": "Group Maven updates",
-      "matchManagers": ["maven"],
-      "groupName": "Maven dependencies",
-      "groupSlug": "maven-dependencies"
-    },
-    {
-      "description": "Group Mise tool updates",
-      "matchManagers": ["mise"],
-      "groupName": "Mise tool dependencies",
-      "groupSlug": "mise-tool-dependencies"
-    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>SonarSource/renovate-config"
+    "local>SonarSource/core-languages-tooling-public:renovate-config"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,27 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>SonarSource/core-languages-tooling-public:renovate-config"
+  ],
+  "rebaseWhen": "conflicted",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions dependencies",
+      "groupSlug": "github-actions-dependencies"
+    },
+    {
+      "description": "Group Maven updates",
+      "matchManagers": ["maven"],
+      "groupName": "Maven dependencies",
+      "groupSlug": "maven-dependencies"
+    },
+    {
+      "description": "Group Mise tool updates",
+      "matchManagers": ["mise"],
+      "groupName": "Mise tool dependencies",
+      "groupSlug": "mise-tool-dependencies"
+    }
   ]
 }


### PR DESCRIPTION
This switches the repository from the SonarSource root Renovate preset to the squad preset in `SonarSource/core-languages-tooling-public:renovate-config` and keeps only repo-specific overrides.

## Effective Delta After Merge
<!-- codex-effective-delta:start -->
- onboarding Renovate
<!-- codex-effective-delta:end -->
