### PR TITLE
SONARIAC-3030 SecretClassifier: Filter our empty passwords

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -93,7 +93,7 @@ public final class SecretClassifier {
     // Trivially fake or weak literal values.
     PatternGroup.of(Category.FAKE_VALUE,
       // Expect minimum length of 6 characters
-      "^.{1,5}$",
+      "^.{0,5}$",
       // Words usually found in fake secrets, e.g. "samplepassword", "EXAMPLE_SECRET"
       "sample|example|placeholder|replace|change|foo|bar|test|fake|abcd",
       "redacted|cafebabe|deadbeef|whatever|123456|default|dummy|qwerty|setting|obfuscated",

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
@@ -37,6 +37,7 @@ class SecretClassifierTest {
   // sample here fails coverageShouldExerciseEveryPatternAndExactValue.
   static final List<String> KNOWN_NON_SECRETS = List.of(
     // FAKE_VALUE
+    "", // Empty password
     "abc", // minimum length
     "samplepassword", "EXAMPLE_SECRET", "deadbeef", "qwerty", // fake words (substring)
     "password1234", "passwd", // password-like


### PR DESCRIPTION
Part of SONARIAC-3020

----
## Summary by Gitar

- **Secret classification:**
  - Modified `SecretClassifier.java` regex to include empty strings as `FAKE_VALUE`.
  - Added an empty string case to `KNOWN_NON_SECRETS` in `SecretClassifierTest.java`.

<sub>This will update automatically on new commits.</sub>