### PR TITLE
ACOMMONS-69 Prepare for next development iteration

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.analyzer-commons</groupId>
     <artifactId>sonar-analyzer-commons-parent</artifactId>
-    <version>2.25.0-SNAPSHOT</version>
+    <version>2.26.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-analyzer-commons</artifactId>

--- a/performance-measure/pom.xml
+++ b/performance-measure/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>sonar-analyzer-commons-parent</artifactId>
     <groupId>org.sonarsource.analyzer-commons</groupId>
-    <version>2.25.0-SNAPSHOT</version>
+    <version>2.26.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-performance-measure</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.sonarsource.analyzer-commons</groupId>
   <artifactId>sonar-analyzer-commons-parent</artifactId>
-  <version>2.25.0-SNAPSHOT</version>
+  <version>2.26.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>SonarSource Analyzers Commons Parent</name>

--- a/recognizers/pom.xml
+++ b/recognizers/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.analyzer-commons</groupId>
     <artifactId>sonar-analyzer-commons-parent</artifactId>
-    <version>2.25.0-SNAPSHOT</version>
+    <version>2.26.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-analyzer-recognizers</artifactId>

--- a/regex-parsing/pom.xml
+++ b/regex-parsing/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>sonar-analyzer-commons-parent</artifactId>
     <groupId>org.sonarsource.analyzer-commons</groupId>
-    <version>2.25.0-SNAPSHOT</version>
+    <version>2.26.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-regex-parsing</artifactId>

--- a/test-commons/pom.xml
+++ b/test-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.analyzer-commons</groupId>
     <artifactId>sonar-analyzer-commons-parent</artifactId>
-    <version>2.25.0-SNAPSHOT</version>
+    <version>2.26.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-analyzer-test-commons</artifactId>

--- a/test-xml-parsing/pom.xml
+++ b/test-xml-parsing/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>sonar-analyzer-commons-parent</artifactId>
     <groupId>org.sonarsource.analyzer-commons</groupId>
-    <version>2.25.0-SNAPSHOT</version>
+    <version>2.26.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-sonar-xml-parsing</artifactId>

--- a/xml-parsing/pom.xml
+++ b/xml-parsing/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>sonar-analyzer-commons-parent</artifactId>
     <groupId>org.sonarsource.analyzer-commons</groupId>
-    <version>2.25.0-SNAPSHOT</version>
+    <version>2.26.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-xml-parsing</artifactId>


### PR DESCRIPTION
## Summary
- Bump version from `2.25.0-SNAPSHOT` to `2.26.0-SNAPSHOT` across all module poms, following the release of 2.25.0.

## Test plan
- CI build should pass with no functional changes.