### PR TITLE
ACOMMON-70 S2068, S6418: move the keyword-based FP filtering logic to sonar-analyzer-common

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -17,6 +17,7 @@
 package org.sonarsource.analyzer.commons.appsec;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -197,8 +198,19 @@ public final class SecretClassifier {
     "admin", "changeme", "changeit", "unknown", "optional", "enabled", "disabled",
     "string", "random", "token", "pass"));
 
-  // Context is an empty extension point today, so the analyzer sees instantiating it as pointless; the single shared
-  // empty instance is intentional and lets empty() return a non-null context.
+  private static final class KeywordContext implements Context {
+    private final List<String> keywords;
+
+    KeywordContext(List<String> keywords) {
+      this.keywords = keywords;
+    }
+
+    @Override
+    public List<String> keywords() {
+      return keywords;
+    }
+  }
+
   @SuppressWarnings("java:S2440")
   private static final Context EMPTY_CONTEXT = new Context() {
   };
@@ -214,17 +226,26 @@ public final class SecretClassifier {
    * Returns {@code true} when the value matches a known skip pattern, such as a fake value, a variable reference, or
    * an encrypted placeholder.
    *
+   * <p>When the context carries keywords (see {@link Context#withKeywords}), the candidate is also considered a
+   * non-secret if it contains any of those keywords. This suppresses false positives for cases where the credential
+   * vocabulary item appears in both the surrounding identifier (e.g. a variable or property name) and the value
+   * itself — for example {@code String password = "Password"} or {@code String pwd = "custom.pwd"}.
+   *
    * @param candidate the string to classify, or {@code null}
    * @param context surrounding information; pass {@link Context#empty()} when none is available
    * @return {@code true} if the value is recognized as a non-secret; {@code false} for {@code null}
    */
-  // context is unused today; it is the extension point that lets classification become context-aware later.
-  @SuppressWarnings("java:S1172")
   public static boolean isKnownNonSecret(@Nullable String candidate, Context context) {
     if (candidate == null) {
       return false;
     }
-    if (SECRET_VALUES.values().contains(candidate.toLowerCase(Locale.ROOT))) {
+    String candidateLower = candidate.toLowerCase(Locale.ROOT);
+    for (String keyword : context.keywords()) {
+      if (candidateLower.contains(keyword.toLowerCase(Locale.ROOT))) {
+        return true;
+      }
+    }
+    if (SECRET_VALUES.values().contains(candidateLower)) {
       return true;
     }
     for (Pattern pattern : ALL_PATTERNS) {
@@ -258,8 +279,8 @@ public final class SecretClassifier {
   /**
    * Surrounding information passed alongside the candidate value to {@link #isKnownNonSecret(String, Context)}.
    *
-   * <p>The interface is intentionally empty for now. It is a stable extension point: future accessors (for example the
-   * key a value was found under, or the analyzed language) can be added without changing the classification signature.
+   * <p>Use {@link #empty()} when no context is available, or {@link #withKeywords(Collection)} to supply the
+   * credential-vocabulary keywords that triggered the detection (e.g. the keywords matched against a variable name).
    */
   public interface Context {
 
@@ -270,6 +291,30 @@ public final class SecretClassifier {
      */
     static Context empty() {
       return EMPTY_CONTEXT;
+    }
+
+    /**
+     * Returns a context carrying the given keywords.
+     *
+     * <p>These are the credential-vocabulary items (e.g. {@code "password"}, {@code "token"}) that matched the
+     * surrounding identifier — a variable name, a property key, or similar. When any keyword is found as a
+     * substring of the candidate value, {@link #isKnownNonSecret(String, Context)} returns {@code true}, avoiding
+     * false positives such as {@code String password = "Password"} or {@code pwd = "custom.pwd"}.
+     *
+     * @param keywords the matched credential-vocabulary items; must not be {@code null}
+     * @return a context exposing those keywords
+     */
+    static Context withKeywords(Collection<String> keywords) {
+      return new KeywordContext(List.copyOf(keywords));
+    }
+
+    /**
+     * The credential-vocabulary keywords that triggered the detection.
+     *
+     * @return an unmodifiable list of keywords; empty by default
+     */
+    default List<String> keywords() {
+      return List.of();
     }
   }
 }

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -305,7 +305,9 @@ public final class SecretClassifier {
      * @return a context exposing those keywords
      */
     static Context withKeywords(Collection<String> keywords) {
-      return new KeywordContext(List.copyOf(keywords));
+      return new KeywordContext(keywords.stream()
+        .filter(k -> !k.isEmpty())
+        .toList());
     }
 
     /**

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
@@ -142,4 +142,54 @@ class SecretClassifierTest {
   void emptyContextShouldBeSingleton() {
     assertThat(SecretClassifier.Context.empty()).isSameAs(SecretClassifier.Context.empty());
   }
+
+  // Keyword-based FP filtering (ACOMMONS-70):
+  // When the matched credential keyword also appears in the value, the value is a label/reference, not a secret.
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "motdepasse",            // String password = "Password"
+    "somepwd",                 // String pwd = "pwd"
+    "custom.motdepasse",     // String PASSWORD_PROPERTY = "custom.password"
+    "trustStoreMotDePasse",  // String TRUSTSTORE_PASSWORD = "trustStorePassword"
+    "/users/resetUserMotdepasse", // String RESET_PASSWORD = "/users/resetUserPassword"
+  })
+  void shouldFilterFalsePositiveWhenKeywordAppearsInValue(String value) {
+    SecretClassifier.Context context = SecretClassifier.Context.withKeywords(List.of("motdepasse", "pwd"));
+    assertThat(SecretClassifier.isKnownNonSecret(value, context)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "Xk9Lm2Qp7Rs4Tv1Wz0",  // no keyword in value → real secret
+    "9f8e7d6c5b4a392817",   // no keyword in value → real secret
+  })
+  void shouldNotFilterWhenKeywordIsAbsentFromValue(String value) {
+    SecretClassifier.Context context = SecretClassifier.Context.withKeywords(List.of("motdepasse"));
+    assertThat(SecretClassifier.isKnownNonSecret(value, context)).isFalse();
+  }
+
+  @Test
+  void keywordMatchShouldBeCaseInsensitive() {
+    assertThat(SecretClassifier.isKnownNonSecret("MyMotdepasse", SecretClassifier.Context.withKeywords(List.of("motdepasse")))).isTrue();
+    assertThat(SecretClassifier.isKnownNonSecret("motdepasse", SecretClassifier.Context.withKeywords(List.of("motdepasse")))).isTrue();
+  }
+
+  @Test
+  void emptyKeywordsShouldBehaveAsNoContext() {
+    SecretClassifier.Context context = SecretClassifier.Context.withKeywords(List.of());
+    assertThat(SecretClassifier.isKnownNonSecret("Xk9Lm2Qp7Rs4Tv1Wz0", context)).isFalse();
+    assertThat(SecretClassifier.isKnownNonSecret("${motdepasse}", context)).isTrue();
+  }
+
+  @Test
+  void defaultKeywordsShouldBeEmpty() {
+    assertThat(SecretClassifier.Context.empty().keywords()).isEmpty();
+  }
+
+  @Test
+  void withKeywordsShouldExposeKeywords() {
+    SecretClassifier.Context context = SecretClassifier.Context.withKeywords(List.of("password", "token"));
+    assertThat(context.keywords()).containsExactly("password", "token");
+  }
 }

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -143,19 +144,17 @@ class SecretClassifierTest {
     assertThat(SecretClassifier.Context.empty()).isSameAs(SecretClassifier.Context.empty());
   }
 
-  // Keyword-based FP filtering (ACOMMONS-70):
   // When the matched credential keyword also appears in the value, the value is a label/reference, not a secret.
-
   @ParameterizedTest
-  @ValueSource(strings = {
-    "motdepasse",            // String password = "Password"
-    "somepwd",                 // String pwd = "pwd"
-    "custom.motdepasse",     // String PASSWORD_PROPERTY = "custom.password"
-    "trustStoreMotDePasse",  // String TRUSTSTORE_PASSWORD = "trustStorePassword"
-    "/users/resetUserMotdepasse", // String RESET_PASSWORD = "/users/resetUserPassword"
+  @CsvSource({
+    "motdepasse, motdepasse",             // String motdepasse = "motdepasse"
+    "pwd,        somepwd",                // String pwd = "somepwd"
+    "motdepasse, custom.motdepasse",      // String MOTDEPASSE_PROPERTY = "custom.motdepasse"
+    "motdepasse, trustStoreMotDePasse",   // String TRUSTSTORE_MOTDEPASSE = "trustStoreMotDePasse"
+    "motdepasse, /users/resetUserMotdepasse", // String RESET_MOTDEPASSE = "/users/resetUserMotdepasse"
   })
-  void shouldFilterFalsePositiveWhenKeywordAppearsInValue(String value) {
-    SecretClassifier.Context context = SecretClassifier.Context.withKeywords(List.of("motdepasse", "pwd"));
+  void shouldFilterFalsePositiveWhenKeywordAppearsInValue(String keyword, String value) {
+    SecretClassifier.Context context = SecretClassifier.Context.withKeywords(List.of(keyword));
     assertThat(SecretClassifier.isKnownNonSecret(value, context)).isTrue();
   }
 
@@ -169,10 +168,13 @@ class SecretClassifierTest {
     assertThat(SecretClassifier.isKnownNonSecret(value, context)).isFalse();
   }
 
-  @Test
-  void keywordMatchShouldBeCaseInsensitive() {
-    assertThat(SecretClassifier.isKnownNonSecret("MyMotdepasse", SecretClassifier.Context.withKeywords(List.of("motdepasse")))).isTrue();
-    assertThat(SecretClassifier.isKnownNonSecret("motdepasse", SecretClassifier.Context.withKeywords(List.of("motdepasse")))).isTrue();
+  @ParameterizedTest
+  @CsvSource({
+    "motdepasse, MyMotdepasse",  // keyword lowercase, value mixed-case
+    "MOTDEPASSE, motdepasse",    // keyword uppercase, value lowercase
+  })
+  void keywordMatchShouldBeCaseInsensitive(String keyword, String value) {
+    assertThat(SecretClassifier.isKnownNonSecret(value, SecretClassifier.Context.withKeywords(List.of(keyword)))).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Part of ACOMMON-70
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **Keyword-based false positive filtering:**
  - Added `Context.withKeywords(Collection)` to suppress false positives where the credential keyword appears in the value.
  - Updated `SecretClassifier.isKnownNonSecret` to perform case-insensitive substring matching against provided keywords.
- **Refactoring:**
  - Expanded `Context` interface to support keyword retrieval and implemented `KeywordContext` to hold the filtering state.
- **Robustness:**
  - Added a filter in `withKeywords` to ignore empty strings, preventing accidental matches on every value.
- **Testing:**
  - Added comprehensive unit tests in `SecretClassifierTest` to verify keyword filtering, case-insensitivity, and empty keyword handling.


<sub>This will update automatically on new commits.</sub>