### PR TITLE
APPSEC-3475 SecretClassifier: Add double-underscore-wrapped placeholder pattern

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -152,7 +152,9 @@ public final class SecretClassifier {
       // Python format string placeholders, e.g. "%(password)s"
       "^%\\([^)]++\\)s$",
       // Azure Logic Apps runtime expressions, e.g. "@variables('name')", "@body('action')"
-      "^@\\w++\\([^)]*+\\)$"),
+      "^@\\w++\\([^)]*+\\)$",
+      // Double-underscore-wrapped placeholders, e.g. "__some_placeholder_password__"
+      "^__.+__$"),
 
     // Encrypted markers wrapping a ciphertext.
     PatternGroup.of(Category.ENCRYPTED,

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -108,9 +108,7 @@ public final class SecretClassifier {
       // Same character repeated from start to end, e.g. "aa", "111111"
       "^(?<repeated>.)\\k<repeated>*+$",
       // A secret being masked or shortened, e.g. "1fj28...askn3i"
-      "\\.\\.\\.",
-      // Code-reminder placeholder markers left as a value (see the regex)
-      "^(?:todo|fixme)\\b"),
+      "\\.\\.\\."),
 
     // Templating, interpolation and env/config lookups where the value comes from elsewhere.
     PatternGroup.of(Category.PLACEHOLDER,
@@ -154,7 +152,9 @@ public final class SecretClassifier {
       // Azure Logic Apps runtime expressions, e.g. "@variables('name')", "@body('action')"
       "^@\\w++\\([^)]*+\\)$",
       // Double-underscore-wrapped placeholders, e.g. "__some_placeholder_password__"
-      "^__.+__$"),
+      "^__.+__$",
+      // Code-reminder prefix left as the full credential value, e.g. "TODO: replace with real key"
+      "^(?:todo|fixme)\\b"),
 
     // Encrypted markers wrapping a ciphertext.
     PatternGroup.of(Category.ENCRYPTED,
@@ -255,6 +255,25 @@ public final class SecretClassifier {
   /** Visible for testing: the exact-match values. */
   static Set<String> exactMatchValues() {
     return SECRET_VALUES.values();
+  }
+
+  /** Visible for testing: returns the {@link Category} that suppressed the candidate, or {@code null} when not a known non-secret. */
+  @Nullable
+  static Category classify(@Nullable String candidate) {
+    if (candidate == null) {
+      return null;
+    }
+    if (SECRET_VALUES.values().contains(candidate.toLowerCase(Locale.ROOT))) {
+      return Category.SECRET;
+    }
+    for (PatternGroup group : PATTERN_GROUPS) {
+      for (Pattern pattern : group.patterns()) {
+        if (pattern.matcher(candidate).find()) {
+          return group.category;
+        }
+      }
+    }
+    return null;
   }
 
   /**

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -153,7 +153,7 @@ public final class SecretClassifier {
       "^@\\w++\\([^)]*+\\)$",
       // Double-underscore-wrapped placeholders, e.g. "__some_placeholder_password__"
       "^__.+__$",
-      // Code-reminder prefix left as the full credential value, e.g. "TODO: replace with real key"
+      // Code-reminder prefix left as the full credential value, e.g. "(prefix): replace with real key"
       "^(?:todo|fixme)\\b"),
 
     // Encrypted markers wrapping a ciphertext.

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
@@ -18,6 +18,7 @@ package org.sonarsource.analyzer.commons.appsec;
 
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,38 +33,139 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class SecretClassifierTest {
 
-  // One representative value per skip pattern / exact value, grouped by category. Drives both the
-  // "classified as non-secret" check and the coverage check below, so adding a pattern without a
-  // sample here fails coverageShouldExerciseEveryPatternAndExactValue.
-  static final List<String> KNOWN_NON_SECRETS = List.of(
-    // FAKE_VALUE
-    "", // Empty password
-    "abc", // minimum length
-    "samplepassword", "EXAMPLE_SECRET", "deadbeef", "qwerty", // fake words (substring)
-    "password1234", "passwd", // password-like
-    "undefined", "true", "null", // boolean / null / scalar literals
-    "yourpassword", // starts with "your"
-    "abbbbc", // same character 4 times
-    "111111", // same character start to end
-    "1fj28...askn3i", // masked
-    "TODO: replace me", "FIXME", // reminder/placeholder prefix
-    "admin123", "vncpass", "super-secret-p4ssw0rd", // FAKE_VALUE
-    // SECRET (exact match, case-insensitive)
+  // One representative value per pattern / exact value, grouped by category.
+  // Each value must be suppressed by the category it is listed under, not by an earlier group.
+  // Adding a pattern without a sample here fails coverageShouldExerciseEveryPatternAndExactValue.
+
+  static final List<String> FAKE_VALUE_SAMPLES = List.of(
+    // Minimum length
+    "", "abc",
+    // Fake-word substrings
+    "samplepassword", "EXAMPLE_SECRET", "deadbeef", "qwerty",
+    // Templates whose placeholder names contain credential words — FAKE_VALUE wins before PLACEHOLDER
+    "${secret}", "#{{secret}}", "$foo_bar",
+    // Password-like values
+    "password1234", "passwd",
+    // Boolean / null / scalar literals
+    "undefined", "true", "null",
+    // "your..." prefix
+    "yourpassword",
+    // Same-character repetitions
+    "abbbbc", "111111",
+    // Masked value
+    "1fj28...askn3i",
+    // Other fake keywords
+    "admin123", "vncpass", "super-secret-p4ssw0rd",
+    // "secret" in "secretsmanager" triggers FAKE_VALUE before REFERENCE; kept here for REFERENCE ARN pattern coverage
+    "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-pass");
+
+  static final List<String> SECRET_SAMPLES = List.of(
     "hunter2", "letmein", "abc123",
-    "changeme", "changeit", "unknown", "optional", "enabled", "disabled", "string", "random", "token",
-    // PLACEHOLDER
-    "__some_placeholder_password__",
-    "${secret}", "value-${pwd}", "#{{secret}}", "((db-password))",
-    "$(echo $PASSWORD)", "`echo $PASSWORD`", "$foo_bar",
-    "{secret}", "%{secret}", "{{secret}}",
-    "System.getenv(\"secret\")", "process.env.MY_SECRET", "%GITHUB_TOKEN%", "config['secret']", "Read-Host",
-    "<password>", "(password)", "[password]", "%(password)s", "@variables('name')",
-    // ENCRYPTED
-    "encrypted:YWJjZGVm", "{cipher}1e3faa2cdab2deae117dca102e52922a", "enc[QUJDRA==]", "ENC{abcdef}", "%enc{QUJDRA==}", "ENC(abcdef)",
-    // REFERENCE
-    "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-pass", "op://vault/item/password", "VAULT[path/to/secret access_token]",
-    // STRUCTURED_FORMAT
-    "/var/keys/gsa-key.json", "v1.2.3", ">=1.0.0", "~1.4.5-alpha", "4.0.9(@types/node@22.13.4)");
+    "changeme", "changeit", "unknown", "optional", "enabled", "disabled", "string", "random", "token");
+
+  static final List<String> PLACEHOLDER_SAMPLES = List.of(
+    "__api_key__",                        // double-underscore-wrapped
+    "TODO: fill in", "FIXME: fill in",   // code-reminder prefix
+    "${env_var}", "value-${env_var}",     // variable interpolation
+    "#{{db_host}}",                       // hash-brace interpolation
+    "((vault_ref))",                      // Concourse vars
+    "$(get_key)",                         // shell command substitution
+    "`get_key`",                          // backtick command substitution
+    "$MY_VAR",                            // bare variable reference
+    "{db_host}", "%{db_host}",            // template interpolation
+    "{{db_host}}",                        // double-brace interpolation
+    "System.getenv(\"DB_HOST\")",         // env access
+    "process.env.HOST",                   // Node.js process.env
+    "%GITHUB_TOKEN%",                     // %VAR% syntax
+    "config['db_url']",                   // config access
+    "Read-Host",                          // PowerShell
+    "<db-host>",                          // short angle-bracket placeholder
+    "<api_endpoint>",                     // long angle-bracket placeholder
+    "(config_ref)",                       // parenthesised placeholder
+    "[db_url]",                           // square-bracket placeholder
+    "%(db_url)s",                         // Python format-string placeholder
+    "@variables('host')");                // Azure Logic Apps expression
+
+  static final List<String> ENCRYPTED_SAMPLES = List.of(
+    "encrypted:YWJjZGVm",
+    "{cipher}1e3faa2cdab2deae117dca102e52922a",
+    "enc[QUJDRA==]",
+    "ENC{QUJDRA==}", "%enc{QUJDRA==}", "ENC(QUJDRA==)");
+
+  static final List<String> REFERENCE_SAMPLES = List.of(
+    "op://vault/item/key",
+    "VAULT[path/to/key access_token]");
+
+  static final List<String> STRUCTURED_FORMAT_SAMPLES = List.of(
+    "/var/keys/gsa-key.json",
+    "v1.2.3", ">=1.0.0", "~1.4.5-alpha",                // semver variants
+    "4.0.9(@types/node@22.13.4)");                       // peer-annotated lockfile version (non-semver)
+
+  static final List<String> KNOWN_NON_SECRETS = Stream.of(
+    FAKE_VALUE_SAMPLES, SECRET_SAMPLES, PLACEHOLDER_SAMPLES,
+    ENCRYPTED_SAMPLES, REFERENCE_SAMPLES, STRUCTURED_FORMAT_SAMPLES)
+    .flatMap(List::stream)
+    .collect(Collectors.toUnmodifiableList());
+
+  static Stream<String> fakeValueSamples() {
+    return FAKE_VALUE_SAMPLES.stream();
+  }
+
+  static Stream<String> secretSamples() {
+    return SECRET_SAMPLES.stream();
+  }
+
+  static Stream<String> placeholderSamples() {
+    return PLACEHOLDER_SAMPLES.stream();
+  }
+
+  static Stream<String> encryptedSamples() {
+    return ENCRYPTED_SAMPLES.stream();
+  }
+
+  static Stream<String> referenceSamples() {
+    return REFERENCE_SAMPLES.stream();
+  }
+
+  static Stream<String> structuredFormatSamples() {
+    return STRUCTURED_FORMAT_SAMPLES.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource("fakeValueSamples")
+  void shouldBeSuppressedByFakeValueCategory(String value) {
+    assertThat(SecretClassifier.classify(value)).isEqualTo(SecretClassifier.Category.FAKE_VALUE);
+  }
+
+  @ParameterizedTest
+  @MethodSource("secretSamples")
+  void shouldBeSuppressedBySecretCategory(String value) {
+    assertThat(SecretClassifier.classify(value)).isEqualTo(SecretClassifier.Category.SECRET);
+  }
+
+  @ParameterizedTest
+  @MethodSource("placeholderSamples")
+  void shouldBeSuppressedByPlaceholderCategory(String value) {
+    assertThat(SecretClassifier.classify(value)).isEqualTo(SecretClassifier.Category.PLACEHOLDER);
+  }
+
+  @ParameterizedTest
+  @MethodSource("encryptedSamples")
+  void shouldBeSuppressedByEncryptedCategory(String value) {
+    assertThat(SecretClassifier.classify(value)).isEqualTo(SecretClassifier.Category.ENCRYPTED);
+  }
+
+  @ParameterizedTest
+  @MethodSource("referenceSamples")
+  void shouldBeSuppressedByReferenceCategory(String value) {
+    assertThat(SecretClassifier.classify(value)).isEqualTo(SecretClassifier.Category.REFERENCE);
+  }
+
+  @ParameterizedTest
+  @MethodSource("structuredFormatSamples")
+  void shouldBeSuppressedByStructuredFormatCategory(String value) {
+    assertThat(SecretClassifier.classify(value)).isEqualTo(SecretClassifier.Category.STRUCTURED_FORMAT);
+  }
 
   static Stream<String> knownNonSecrets() {
     return KNOWN_NON_SECRETS.stream();
@@ -108,18 +210,6 @@ class SecretClassifierTest {
   })
   void shouldNotExcludeValuesMerelyContainingCredentialWords(String value) {
     assertThat(SecretClassifier.isKnownNonSecret(value)).isFalse();
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {
-    "VAULT[path/to/secret access_token]",
-    "ENC{abcdef}",
-    "4.0.9(@types/node@22.13.4)",
-    "/var/keys/gsa-key.json",
-    "TODO: replace with a real token"
-  })
-  void shouldClassifyNewlyCoveredFormats(String value) {
-    assertThat(SecretClassifier.isKnownNonSecret(value)).isTrue();
   }
 
   @ParameterizedTest

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
@@ -52,6 +52,7 @@ class SecretClassifierTest {
     "hunter2", "letmein", "abc123",
     "changeme", "changeit", "unknown", "optional", "enabled", "disabled", "string", "random", "token",
     // PLACEHOLDER
+    "__some_placeholder_password__",
     "${secret}", "value-${pwd}", "#{{secret}}", "((db-password))",
     "$(echo $PASSWORD)", "`echo $PASSWORD`", "$foo_bar",
     "{secret}", "%{secret}", "{{secret}}",
@@ -92,7 +93,8 @@ class SecretClassifierTest {
   @ValueSource(strings = {
     "Xk9Lm2Qp7Rs4Tv1Wz0",
     "9f8e7d6c5b4a392817",
-    "Tr0ub4dor&3xpl0!t"
+    "Tr0ub4dor&3xpl0!t",
+    "__not_closed" // leading __ without closing __ should not match
   })
   void shouldNotClassifyRealisticTokensAsNonSecrets(String value) {
     assertThat(SecretClassifier.isKnownNonSecret(value)).isFalse();


### PR DESCRIPTION
Adds `^__.+__$` to the PLACEHOLDER pattern group in `SecretClassifier` to recognize double-underscore-wrapped values like `__some_placeholder_password__` as non-secrets. This pattern is commonly used as a placeholder convention in config files.

Noticed during review of SONARXML-374.

Part of APPSEC-3464

----
## Summary by Gitar

- **Code improvements:**
  - Added internal `classify(String)` helper to `SecretClassifier` to expose category detection logic for testing.
- **Testing:**
  - Restructured `SecretClassifierTest` to use granular `MethodSource` and `ParameterizedTest` per classification category.
  - Reorganized `KNOWN_NON_SECRETS` into categorized lists (`FAKE_VALUE_SAMPLES`, `SECRET_SAMPLES`, etc.) for better maintainability.

<sub>This will update automatically on new commits.</sub>