### PR TITLE
ACOMMONS-71 Add TestFileClassifier to analyzer-commons

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifier.java
@@ -109,8 +109,6 @@ public final class TestFileClassifier {
 
   private static boolean isTestSourceConfigured(Configuration config) {
     return isSet(config, "sonar.tests")
-      || isSet(config, "sonar.test.inclusions")
-      || isSet(config, "sonar.test.exclusions")
       || config.getBoolean(HEURISTIC_DISABLED_KEY).orElse(false);
   }
 

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifier.java
@@ -18,6 +18,7 @@ package org.sonarsource.analyzer.commons.appsec;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -64,7 +65,7 @@ public final class TestFileClassifier {
   private final Predicate<Context> detector;
   private final boolean testSourcesConfigured;
   // Warn once, here, so the heuristic behaves the same for every analyzer using this classifier.
-  private boolean heuristicWarningEmitted = false;
+  private final AtomicBoolean heuristicWarningEmitted = new AtomicBoolean(false);
 
   private TestFileClassifier(List<WildcardPattern> patterns, Predicate<Context> detector, boolean testSourcesConfigured) {
     this.patterns = patterns;
@@ -100,8 +101,7 @@ public final class TestFileClassifier {
     String path = inputFile.relativePath();
     boolean detected = !testSourcesConfigured
       && (patterns.stream().anyMatch(pattern -> pattern.match(path)) || detector.test(context));
-    if (detected && !heuristicWarningEmitted) {
-      heuristicWarningEmitted = true;
+    if (detected && heuristicWarningEmitted.compareAndSet(false, true)) {
       LOG.warn(HEURISTIC_APPLIED_WARNING);
     }
     return detected;

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifier.java
@@ -1,0 +1,132 @@
+/*
+ * SonarSource Analyzers Commons
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.analyzer.commons.appsec;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.config.Configuration;
+import org.sonar.api.utils.WildcardPattern;
+
+/**
+ * Test-file heuristic for rule execution only; it never affects metrics, which use the platform
+ * {@link org.sonar.api.batch.fs.InputFile#type()}. Applies only when the project has not declared its
+ * test sources.
+ *
+ * <p>Registered once with the project {@link Configuration} (which gates the heuristic) plus path
+ * globs and, optionally, a {@code detector} for richer checks that reads a caller-supplied
+ * {@link Context}. Per file, {@link #looksLikeTestFile(InputFile)} returns the classification.
+ */
+public final class TestFileClassifier {
+
+  /** Generic opt-out: disables the test-file heuristic for every analyzer that uses this classifier. */
+  public static final String HEURISTIC_DISABLED_KEY = "sonar.testFileHeuristic.disabled";
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestFileClassifier.class);
+
+  private static final String HEURISTIC_APPLIED_WARNING =
+    "Test files were detected using a path heuristic because \"sonar.tests\" is not set. To improve the " +
+      "analysis accuracy, it is recommended to configure it, e.g.: \"sonar.tests=src/test\".";
+
+  private static final class EmptyContext implements Context {}
+
+  // Single shared empty context; held on the outer class so the interface exposes only empty().
+  private static final Context EMPTY_CONTEXT = new EmptyContext();
+
+  // Fallback when no patterns are registered: test directories only, to minimize false positives.
+  private static final List<WildcardPattern> DEFAULT_PATTERNS =
+    Stream.of("**/test/**", "**/tests/**", "**/__tests__/**")
+      .map(WildcardPattern::create)
+      .collect(Collectors.toUnmodifiableList());
+
+  private static final Predicate<Context> NO_DETECTOR = context -> false;
+
+  private final List<WildcardPattern> patterns;
+  private final Predicate<Context> detector;
+  private final boolean testSourcesConfigured;
+  // Warn once, here, so the heuristic behaves the same for every analyzer using this classifier.
+  private boolean heuristicWarningEmitted = false;
+
+  private TestFileClassifier(List<WildcardPattern> patterns, Predicate<Context> detector, boolean testSourcesConfigured) {
+    this.patterns = patterns;
+    this.detector = detector;
+    this.testSourcesConfigured = testSourcesConfigured;
+  }
+
+  /** Registers path {@code globs} (Ant patterns); with none, a generic set of test directories is used. */
+  public static TestFileClassifier of(Configuration configuration, String... globs) {
+    return of(configuration, NO_DETECTOR, globs);
+  }
+
+  /** As {@link #of(Configuration, String...)}, plus a {@code detector} matched when no glob does. */
+  public static TestFileClassifier of(Configuration configuration, Predicate<Context> detector, String... globs) {
+    List<WildcardPattern> patterns = globs.length == 0
+      ? DEFAULT_PATTERNS
+      : Arrays.stream(globs).map(WildcardPattern::create).collect(Collectors.toUnmodifiableList());
+    return new TestFileClassifier(patterns, detector, isTestSourceConfigured(configuration));
+  }
+
+  /** Path-only classification; convenience overload with an empty {@link Context}. */
+  public boolean looksLikeTestFile(InputFile inputFile) {
+    return looksLikeTestFile(inputFile, Context.empty());
+  }
+
+  /**
+   * True when test sources are not configured and either a glob matches the project-relative path or the
+   * detector accepts {@code context}. Warns once when the heuristic first classifies a file.
+   */
+  // relativePath() is the only project-relative accessor
+  @SuppressWarnings("deprecation")
+  public boolean looksLikeTestFile(InputFile inputFile, Context context) {
+    String path = inputFile.relativePath();
+    boolean detected = !testSourcesConfigured
+      && (patterns.stream().anyMatch(pattern -> pattern.match(path)) || detector.test(context));
+    if (detected && !heuristicWarningEmitted) {
+      heuristicWarningEmitted = true;
+      LOG.warn(HEURISTIC_APPLIED_WARNING);
+    }
+    return detected;
+  }
+
+  private static boolean isTestSourceConfigured(Configuration config) {
+    return isSet(config, "sonar.tests")
+      || isSet(config, "sonar.test.inclusions")
+      || isSet(config, "sonar.test.exclusions")
+      || config.getBoolean(HEURISTIC_DISABLED_KEY).orElse(false);
+  }
+
+  private static boolean isSet(Configuration config, String key) {
+    return config.get(key).filter(value -> !value.isBlank()).isPresent();
+  }
+
+  /**
+   * Per-file input a detector inspects. An analyzer implements it to carry what its detector needs
+   * (e.g. the parsed tree) and downcasts to that implementation.
+   */
+  public interface Context {
+
+    /** A context carrying no information; detectors needing more return false. */
+    static Context empty() {
+      return EMPTY_CONTEXT;
+    }
+  }
+}

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifierTest.java
@@ -1,0 +1,171 @@
+/*
+ * SonarSource Analyzers Commons
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.analyzer.commons.appsec;
+
+import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.event.Level;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.config.Configuration;
+import org.sonar.api.config.internal.MapSettings;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestFileClassifierTest {
+
+  @RegisterExtension
+  LogTesterJUnit5 logTester = new LogTesterJUnit5();
+
+  private static final String[] GLOBS = {
+    "**/test/**", "**/tests/**",
+    "**/*Test.java", "**/*Tests.java", "**/*Spec.java", "**/*IT.java"
+  };
+
+  private static Configuration config(String... keyValues) {
+    var settings = new MapSettings();
+    for (int i = 0; i < keyValues.length; i += 2) {
+      settings.setProperty(keyValues[i], keyValues[i + 1]);
+    }
+    return settings.asConfig();
+  }
+
+  private static TestFileClassifier classifier(Configuration config) {
+    return TestFileClassifier.of(config, GLOBS);
+  }
+
+  private static InputFile file(String relativePath) {
+    return new TestInputFileBuilder("module", relativePath).build();
+  }
+
+  // A context flavour an analyzer would supply, carrying structural info its detector reads.
+  private static final class AnnotatedContext implements TestFileClassifier.Context {
+    final boolean hasTestImport;
+
+    AnnotatedContext(boolean hasTestImport) {
+      this.hasTestImport = hasTestImport;
+    }
+  }
+
+  private static final Predicate<TestFileClassifier.Context> IMPORTS_TEST_FRAMEWORK =
+    context -> context instanceof AnnotatedContext && ((AnnotatedContext) context).hasTestImport;
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "src/main/java/FooTest.java",
+    "a/FooTests.java",
+    "a/FooSpec.java",
+    "a/FooIT.java",
+    "src/test/java/Foo.java",
+    "module/tests/Foo.java"
+  })
+  void shouldMatchTestPathsWhenTestSourcesNotConfigured(String path) {
+    assertThat(classifier(config()).looksLikeTestFile(file(path))).isTrue();
+  }
+
+  @Test
+  void shouldFallBackToGenericTestDirectoriesWhenNoPatternsRegistered() {
+    var classifier = TestFileClassifier.of(config()); // no globs registered
+    assertThat(classifier.looksLikeTestFile(file("src/test/java/Foo.java"))).isTrue();
+    assertThat(classifier.looksLikeTestFile(file("a/tests/Foo.java"))).isTrue();
+    assertThat(classifier.looksLikeTestFile(file("a/__tests__/Foo.js"))).isTrue();
+    // fallback matches directories only, not test-named files
+    assertThat(classifier.looksLikeTestFile(file("src/main/java/FooTest.java"))).isFalse();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "src/main/java/Foo.java",
+    "src/main/java/audit.java" // case-sensitive: "audit.java" must not match "*IT.java"
+  })
+  void shouldNotMatchNonTestPaths(String path) {
+    assertThat(classifier(config()).looksLikeTestFile(file(path))).isFalse();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"sonar.tests", "sonar.test.inclusions", "sonar.test.exclusions"})
+  void shouldDisableHeuristicWhenTestSourcesConfigured(String configKey) {
+    assertThat(classifier(config(configKey, "configured")).looksLikeTestFile(file("src/main/java/FooTest.java"))).isFalse();
+  }
+
+  @Test
+  void shouldIgnoreBlankTestSourcesProperty() {
+    assertThat(classifier(config("sonar.tests", "  ")).looksLikeTestFile(file("a/FooTest.java"))).isTrue();
+  }
+
+  @Test
+  void shouldDisableHeuristicOnOptOutProperty() {
+    var classifier = classifier(config(TestFileClassifier.HEURISTIC_DISABLED_KEY, "true"));
+    assertThat(classifier.looksLikeTestFile(file("a/FooTest.java"))).isFalse();
+  }
+
+  @Test
+  void contextOverloadShouldMatchConvenienceOverload() {
+    var classifier = classifier(config());
+    var testFile = file("a/FooTest.java");
+    assertThat(classifier.looksLikeTestFile(testFile, TestFileClassifier.Context.empty()))
+      .isEqualTo(classifier.looksLikeTestFile(testFile));
+  }
+
+  @Test
+  void detectorShouldClassifyFromContextWhenNoPathMatches() {
+    var classifier = TestFileClassifier.of(config(), IMPORTS_TEST_FRAMEWORK);
+    var mainFile = file("src/main/java/Foo.java");
+    assertThat(classifier.looksLikeTestFile(mainFile, new AnnotatedContext(true))).isTrue();
+    assertThat(classifier.looksLikeTestFile(mainFile, new AnnotatedContext(false))).isFalse();
+    // empty context (e.g. a path-only call): the detector cannot classify
+    assertThat(classifier.looksLikeTestFile(mainFile)).isFalse();
+  }
+
+  @Test
+  void detectorAndPatternsShouldBeCombined() {
+    var classifier = TestFileClassifier.of(config(), IMPORTS_TEST_FRAMEWORK, GLOBS);
+    // path pattern hit, no structural info needed
+    assertThat(classifier.looksLikeTestFile(file("a/FooTest.java"))).isTrue();
+    // no path hit, detector hit
+    assertThat(classifier.looksLikeTestFile(file("src/main/java/Foo.java"), new AnnotatedContext(true))).isTrue();
+  }
+
+  @Test
+  void detectorShouldBeGatedByConfiguredTestSources() {
+    var classifier = TestFileClassifier.of(config("sonar.tests", "src/test"), IMPORTS_TEST_FRAMEWORK, GLOBS);
+    assertThat(classifier.looksLikeTestFile(file("src/main/java/Foo.java"), new AnnotatedContext(true))).isFalse();
+  }
+
+  @Test
+  void shouldWarnOnceWhenHeuristicFirstClassifiesATestFile() {
+    var classifier = classifier(config());
+    classifier.looksLikeTestFile(file("a/FooTest.java"));
+    classifier.looksLikeTestFile(file("b/BarTest.java"));
+    classifier.looksLikeTestFile(file("c/Main.java")); // no match, no extra warning
+
+    assertThat(logTester.logs(Level.WARN)).hasSize(1);
+    assertThat(logTester.logs(Level.WARN).get(0)).contains("sonar.tests");
+  }
+
+  @Test
+  void shouldNotWarnWhenTestSourcesAreConfigured() {
+    var classifier = classifier(config("sonar.tests", "src/test"));
+    classifier.looksLikeTestFile(file("a/FooTest.java"));
+
+    assertThat(logTester.logs(Level.WARN)).isEmpty();
+  }
+}

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifierTest.java
@@ -100,10 +100,17 @@ class TestFileClassifierTest {
     assertThat(classifier(config()).looksLikeTestFile(file(path))).isFalse();
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"sonar.tests", "sonar.test.inclusions", "sonar.test.exclusions"})
-  void shouldDisableHeuristicWhenTestSourcesConfigured(String configKey) {
-    assertThat(classifier(config(configKey, "configured")).looksLikeTestFile(file("src/main/java/FooTest.java"))).isFalse();
+  @Test
+  void shouldDisableHeuristicWhenTestSourcesConfigured() {
+    assertThat(classifier(config("sonar.tests", "src/test")).looksLikeTestFile(file("src/main/java/FooTest.java"))).isFalse();
+  }
+
+  @Test
+  void shouldNotDisableHeuristicWhenOnlyInclusionsOrExclusionsConfigured() {
+    // sonar.test.inclusions/exclusions only refine an existing test-source set; they do not declare one
+    var testFile = file("src/main/java/FooTest.java");
+    assertThat(classifier(config("sonar.test.inclusions", "**/*Test.java")).looksLikeTestFile(testFile)).isTrue();
+    assertThat(classifier(config("sonar.test.exclusions", "**/generated/**")).looksLikeTestFile(testFile)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Adds `TestFileClassifier` to `org.sonarsource.analyzer.commons.appsec`. The classifier provides a path heuristic for rules to suppress findings on test files when test sources are not explicitly configured. It is a no-op whenever `sonar.tests` is set, so it never overrides an intentional project configuration. It warns once when the heuristic first fires, prompting users to configure `sonar.tests` for better accuracy.

Key behaviors:
- Ant-glob matching on the project-relative path; falls back to generic test directories (`**/test/**`, `**/tests/**`, `**/__tests__/**`) when no globs are supplied
- Optional `Predicate<Context>` for richer structural detection (e.g. scanning imports)
- Global opt-out via `sonar.testFileHeuristic.disabled`
- Warn-once flag is an `AtomicBoolean` so the message is logged exactly once under parallel analysis

----
## Summary by Gitar

- **New Classifier:**
  - Added `TestFileClassifier` to `org.sonarsource.analyzer.commons.appsec` to provide a path-based heuristic for identifying test files.
- **Secret Detection:**
  - Updated `SecretClassifier` to include `__` wrapped patterns (e.g., `__placeholder__`) as known non-secret placeholders.
- **Test Coverage:**
  - Added `TestFileClassifierTest` verifying path-based matching, directory fallbacks, detector logic, and configuration opt-outs.

<sub>This will update automatically on new commits.</sub>
