### PR TITLE
CLP-129 Normalize Jira automation workflows

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -5,9 +5,9 @@ on:
     types: [closed]
 
 jobs:
-  PullRequestMerged_job:
-    name: Pull Request Merged
-    runs-on: github-ubuntu-latest-s
+  PullRequestClosed_job:
+    name: Pull Request Closed
+    runs-on: sonar-xs
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -26,10 +26,3 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
-
-  PR_Build_Cleanup:
-    runs-on: sonar-xs
-    permissions:
-      actions: write
-    steps:
-      - uses: SonarSource/ci-github-actions/pr_cleanup@v1

--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -24,5 +24,12 @@ jobs:
       - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@v2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          jira-user:  ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
-          jira-token: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
+          jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+
+  PR_Build_Cleanup:
+    runs-on: sonar-xs
+    permissions:
+      actions: write
+    steps:
+      - uses: SonarSource/ci-github-actions/pr_cleanup@v1

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,12 +7,13 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
     # For external PR, ticket should be created manually
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
+        && github.event.sender.type != 'Bot'
     steps:
       - id: secrets
         uses: SonarSource/vault-action-wrapper@v3

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -13,7 +13,6 @@ jobs:
     # For external PR, ticket should be created manually
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
-        && github.event.sender.type != 'Bot'
     steps:
       - id: secrets
         uses: SonarSource/vault-action-wrapper@v3

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -26,5 +26,5 @@ jobs:
       - uses: sonarsource/gh-action-lt-backlog/SubmitReview@v2
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
-          jira-user: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
-          jira-token: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
+          jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually


### PR DESCRIPTION
## Summary
- normalize Jira automation workflows to the agreed CLP-129 baseline
- align the four Jira workflow files on the common shape and `@v2` action references
- add or normalize the shared PR template where needed

## Testing
- not run (GitHub workflow configuration changes only)

----
## Summary by Gitar

- **Workflow configuration:**
  - Migrated job runners from `github-ubuntu-latest-s` to `sonar-xs` across all Jira automation workflows.
- **Job additions:**
  - Added `PR_Build_Cleanup` job to `PullRequestClosed.yml` using `SonarSource/ci-github-actions/pr_cleanup@v1`.

<sub>This will update automatically on new commits.</sub>