### PR TITLE
ACOMMONS-78 Expose the regexes from SecretClassifier as JSON file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,15 @@ concurrency:
 
 jobs:
   build:
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     name: Build
     permissions:
       id-token: write  # Required for Vault OIDC authentication
       contents: write  # Required for repository access and tagging
+    outputs:
+      # Consumed by the promote-nuget job to promote the matching NuGet build-info.
+      build-number: ${{ steps.build-maven.outputs.BUILD_NUMBER }}
+      deployed: ${{ steps.build-maven.outputs.deployed }}
     steps:
       - &checkout
         name: Checkout source code
@@ -40,9 +44,89 @@ jobs:
           artifactory-deployer-role: qa-deployer
           deploy-pull-request: true
 
+      # --- NuGet package: sign with the SonarSource author certificate and publish to the Repox NuGet feed. ---
+      # The Maven build only assembles the .nupkg into target/; it is NOT a Maven artifact. These steps sign it
+      # and upload it to a NuGet-layout repo so .NET projects can consume it. Only runs when Maven actually deployed.
+      - name: Prepare NuGet package
+        id: nupkg
+        if: steps.build-maven.outputs.deployed == 'true'
+        shell: bash
+        env:
+          PROJECT_VERSION: ${{ steps.build-maven.outputs.project-version }}
+        run: |
+          set -euo pipefail
+          MODULE=sonar-analyzer-commons-configurations
+          # package.version is project.version with -SNAPSHOT stripped (in CI there is no -SNAPSHOT suffix).
+          PKG_VERSION="${PROJECT_VERSION%-SNAPSHOT}"
+          # Must equal the nuspec <id>; the feed derives the package identity from the "<id>.<version>.nupkg" name.
+          PKG_ID=SonarAnalyzer.CommonsConfigurations
+          SRC="${MODULE}/target/${MODULE}-${PROJECT_VERSION}-nupkg.zip"
+          OUT_DIR=nuget-staging
+          if [[ ! -f "$SRC" ]]; then
+            echo "::error::Expected NuGet package not found at $SRC"
+            ls -la "${MODULE}/target" || true
+            exit 1
+          fi
+          rm -rf "$OUT_DIR"
+          mkdir -p "$OUT_DIR"
+          cp "$SRC" "${OUT_DIR}/${PKG_ID}.${PKG_VERSION}.nupkg"
+          {
+            echo "dir=${OUT_DIR}"
+            echo "id=${PKG_ID}"
+            echo "version=${PKG_VERSION}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sign NuGet package
+        if: steps.build-maven.outputs.deployed == 'true'
+        uses: SonarSource/gh-action_azure-artifact-signing@v1
+        with:
+          mode: sign
+          files: ${{ steps.nupkg.outputs.dir }}/*.nupkg
+
+      - name: Install jfrog-cli
+        if: steps.build-maven.outputs.deployed == 'true'
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
+        with:
+          cache: true
+          tool_versions: |
+            jfrog-cli 2.103
+
+      - name: Get NuGet deployer token
+        id: nuget-secrets
+        if: steps.build-maven.outputs.deployed == 'true'
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-qa-deployer access_token | ARTIFACTORY_ACCESS_TOKEN;
+
+      - name: Deploy signed NuGet package to Repox
+        if: steps.build-maven.outputs.deployed == 'true'
+        shell: bash
+        env:
+          ARTIFACTORY_ACCESS_TOKEN: ${{ steps.nuget-secrets.outputs.vault && fromJSON(steps.nuget-secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN || '' }}
+          BUILD_NUMBER: ${{ steps.build-maven.outputs.BUILD_NUMBER }}
+          NUPKG_DIR: ${{ steps.nupkg.outputs.dir }}
+          NUPKG_ID: ${{ steps.nupkg.outputs.id }}
+          NUPKG_VERSION: ${{ steps.nupkg.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Separate build-info name so it does not collide with the Maven build-info (github.repository name).
+          BUILD_NAME="${GITHUB_REPOSITORY#*/}_nuget"
+          MODULE_GAV="org.sonarsource.analyzer-commons:${NUPKG_ID}:${NUPKG_VERSION}"
+          jf config add repox \
+            --artifactory-url="https://repox.jfrog.io/artifactory" \
+            --access-token="$ARTIFACTORY_ACCESS_TOKEN" \
+            --interactive=false
+          jf config use repox
+          jf rt upload --flat \
+            --build-name="$BUILD_NAME" --build-number="$BUILD_NUMBER" --module="$MODULE_GAV" \
+            "${NUPKG_DIR}/*.nupkg" "sonarsource-nuget-qa/"
+          jf rt build-collect-env "$BUILD_NAME" "$BUILD_NUMBER"
+          jf rt build-publish "$BUILD_NAME" "$BUILD_NUMBER"
+
   promote:
     needs: [ build ]
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     name: Promote
     permissions:
       id-token: write
@@ -53,3 +137,58 @@ jobs:
         uses: SonarSource/ci-github-actions/promote@v1
         with:
           promote-pull-request: true
+
+  promote-nuget:
+    needs: [ build ]
+    if: needs.build.outputs.deployed == 'true'
+    runs-on: sonar-xs
+    name: Promote NuGet
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Install jfrog-cli
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
+        with:
+          cache: true
+          tool_versions: |
+            jfrog-cli 2.103
+      - name: Get promoter token
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-promoter access_token | PROMOTER_ACCESS_TOKEN;
+      - name: Promote NuGet build
+        shell: bash
+        env:
+          PROMOTER_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).PROMOTER_ACCESS_TOKEN }}
+          BUILD_NUMBER: ${{ needs.build.outputs.build-number }}
+        run: |
+          set -euo pipefail
+          BUILD_NAME="${GITHUB_REPOSITORY#*/}_nuget"
+          # Pull requests are promoted to the dev feed; master/branch-* builds to the public feed.
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            TARGET_REPO=sonarsource-nuget-dev
+            STATUS=it-passed-pr
+          else
+            TARGET_REPO=sonarsource-nuget-public
+            STATUS=it-passed
+          fi
+          jf config add repox \
+            --artifactory-url="https://repox.jfrog.io/artifactory" \
+            --access-token="$PROMOTER_ACCESS_TOKEN" \
+            --interactive=false
+          jf config use repox
+          jf rt build-promote "$BUILD_NAME" "$BUILD_NUMBER" "$TARGET_REPO" \
+            --status="$STATUS" \
+            --source-repo="sonarsource-nuget-qa"
+          # build-promote returns success even when it moves 0 artifacts (e.g. a source-repo
+          # mismatch), which silently leaves nothing in the target feed. Assert the build's
+          # package actually landed so a no-op promotion fails the job instead of looking green.
+          FOUND=$(jf rt search --build="$BUILD_NAME/$BUILD_NUMBER" --count "$TARGET_REPO/*.nupkg")
+          if [[ "${FOUND:-0}" -lt 1 ]]; then
+            echo "::error::NuGet promotion reported success but no .nupkg from ${BUILD_NAME}/${BUILD_NUMBER} is present in ${TARGET_REPO}"
+            exit 1
+          fi
+          echo "Verified ${FOUND} NuGet package(s) from ${BUILD_NAME}/${BUILD_NUMBER} in ${TARGET_REPO}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,45 @@ jobs:
       releaseId: ${{ inputs.releaseId || github.event.release.id }}
       dryRun: ${{ inputs.dryRun == true }}
 
+  # Promote the signed NuGet package from the public build feed to the release feed. The Maven
+  # release above does not handle it (the .nupkg is published to the NuGet feed, not as a Maven artifact).
+  promote-nuget:
+    needs: [release]
+    runs-on: sonar-xs-public
+    name: Promote NuGet to releases
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Install jfrog-cli
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
+        with:
+          cache: true
+          tool_versions: |
+            jfrog-cli 2.103
+      - name: Get promoter token
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-promoter access_token | PROMOTER_ACCESS_TOKEN;
+      - name: Promote NuGet package to releases
+        shell: bash
+        env:
+          PROMOTER_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).PROMOTER_ACCESS_TOKEN }}
+          # The release tag is the full 4-part version, e.g. 2.27.0.5000; the build number is its last segment.
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          BUILD_NAME="${GITHUB_REPOSITORY#*/}_nuget"
+          BUILD_NUMBER="${RELEASE_VERSION##*.}"
+          jf config add repox \
+            --artifactory-url="https://repox.jfrog.io/artifactory" \
+            --access-token="$PROMOTER_ACCESS_TOKEN" \
+            --interactive=false
+          jf config use repox
+          jf rt build-promote "$BUILD_NAME" "$BUILD_NUMBER" "sonarsource-nuget-releases" \
+            --status="Released" \
+            --source-repo="sonarsource-nuget-public" \
+            --copy=true
+

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -273,6 +274,81 @@ public final class SecretClassifier {
       }
     }
     return null;
+  }
+
+  /**
+   * Returns the skip-pattern groups as raw regex source strings, grouped by {@link Category}, in declaration order.
+   *
+   * <p>Exposed so the build can emit a single machine-readable export (JSON) of the very patterns the JVM classifier
+   * uses, keeping non-JVM analyzers (SonarJS, sonar-dotnet, …) in sync without duplicating the list. The patterns are
+   * applied case-insensitively with "find" (search-anywhere) semantics, matching {@link #isKnownNonSecret(String, Context)}.
+   *
+   * @return an immutable, ordered list of pattern groups
+   */
+  public static List<PatternGroupView> exportPatternGroups() {
+    return PATTERN_GROUPS.stream()
+      .map(group -> new PatternGroupView(
+        group.category.name(),
+        group.patterns().stream().map(Pattern::pattern).collect(Collectors.toUnmodifiableList())))
+      .collect(Collectors.toUnmodifiableList());
+  }
+
+  /**
+   * Returns the exact-match value groups, matched in full and case-insensitively, grouped by {@link Category}.
+   * Values are sorted so the export is deterministic.
+   *
+   * @return an immutable, ordered list of exact-match groups
+   */
+  public static List<ExactMatchGroupView> exportExactMatchGroups() {
+    return List.of(new ExactMatchGroupView(
+      SECRET_VALUES.category.name(),
+      SECRET_VALUES.values().stream().sorted().collect(Collectors.toUnmodifiableList())));
+  }
+
+  /**
+   * A group of skip regexes sharing a {@link Category}, exposed for machine-readable export.
+   * The regexes are the raw Java source patterns; callers that target other engines are responsible for any
+   * translation (e.g. possessive quantifiers to atomic groups for .NET).
+   */
+  public static final class PatternGroupView {
+    private final String category;
+    private final List<String> regexes;
+
+    private PatternGroupView(String category, List<String> regexes) {
+      this.category = category;
+      this.regexes = regexes;
+    }
+
+    /** The {@link Category} name this group belongs to. */
+    public String category() {
+      return category;
+    }
+
+    /** The raw regex source strings, in declaration order. */
+    public List<String> regexes() {
+      return regexes;
+    }
+  }
+
+  /** A group of exact-match values sharing a {@link Category}, exposed for machine-readable export. */
+  public static final class ExactMatchGroupView {
+    private final String category;
+    private final List<String> values;
+
+    private ExactMatchGroupView(String category, List<String> values) {
+      this.category = category;
+      this.values = values;
+    }
+
+    /** The {@link Category} name this group belongs to. */
+    public String category() {
+      return category;
+    }
+
+    /** The exact-match values, sorted, matched in full and case-insensitively. */
+    public List<String> values() {
+      return values;
+    }
   }
 
   /**

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -289,8 +289,8 @@ public final class SecretClassifier {
     return PATTERN_GROUPS.stream()
       .map(group -> new PatternGroupView(
         group.category.name(),
-        group.patterns().stream().map(Pattern::pattern).collect(Collectors.toUnmodifiableList())))
-      .collect(Collectors.toUnmodifiableList());
+        group.patterns().stream().map(Pattern::pattern).toList()))
+      .toList();
   }
 
   /**
@@ -302,7 +302,7 @@ public final class SecretClassifier {
   public static List<ExactMatchGroupView> exportExactMatchGroups() {
     return List.of(new ExactMatchGroupView(
       SECRET_VALUES.category.name(),
-      SECRET_VALUES.values().stream().sorted().collect(Collectors.toUnmodifiableList())));
+      SECRET_VALUES.values().stream().sorted().toList()));
   }
 
   /**

--- a/performance-measure/pom.xml
+++ b/performance-measure/pom.xml
@@ -18,7 +18,6 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
 
   <modules>
     <module>commons</module>
+    <module>sonar-analyzer-commons-configurations</module>
     <module>recognizers</module>
     <module>test-commons</module>
     <module>xml-parsing</module>
@@ -80,9 +81,10 @@
     <version.mockito>5.23.0</version.mockito>
     <version.junit>4.13.2</version.junit>
     <version.junit-jupiter>5.14.4</version.junit-jupiter>
+    <version.gson>2.14.0</version.gson>
     <!-- used for deployment to SonarSource Artifactory -->
     <gitRepositoryName>sonar-analyzer-commons</gitRepositoryName>
-    <artifactsToPublish>${project.groupId}:sonar-analyzer-commons:jar,${project.groupId}:sonar-analyzer-test-commons:jar,${project.groupId}:sonar-analyzer-recognizers:jar,${project.groupId}:sonar-xml-parsing:jar,${project.groupId}:test-sonar-xml-parsing:jar,${project.groupId}:sonar-regex-parsing:jar</artifactsToPublish>
+    <artifactsToPublish>${project.groupId}:sonar-analyzer-commons:jar,${project.groupId}:sonar-analyzer-test-commons:jar,${project.groupId}:sonar-analyzer-recognizers:jar,${project.groupId}:sonar-xml-parsing:jar,${project.groupId}:test-sonar-xml-parsing:jar,${project.groupId}:sonar-regex-parsing:jar,${project.groupId}:sonar-analyzer-commons-configurations:json</artifactsToPublish>
     <!-- this property configures the settings in parent pom -->
     <jdk.min.version>17</jdk.min.version>
     <maven.compiler.release>${jdk.min.version}</maven.compiler.release>
@@ -124,6 +126,11 @@
         <groupId>com.googlecode.json-simple</groupId>
         <artifactId>json-simple</artifactId>
         <version>1.1.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>${version.gson}</version>
       </dependency>
 
       <!-- TEST -->

--- a/sonar-analyzer-commons-configurations/pom.xml
+++ b/sonar-analyzer-commons-configurations/pom.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonarsource.analyzer-commons</groupId>
+    <artifactId>sonar-analyzer-commons-parent</artifactId>
+    <version>2.28.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>sonar-analyzer-commons-configurations</artifactId>
+  <name>SonarSource Analyzers Commons Configurations</name>
+  <description>Machine-readable export (JSON, .nupkg, npm .tgz) of shared analyzer configuration generated from
+    sonar-analyzer-commons, so non-JVM analyzers can consume the same secret-exclusion patterns without drift</description>
+
+  <properties>
+    <exporter.mainClass>org.sonarsource.analyzer.commons.appsec.export.SecretPatternsExporter</exporter.mainClass>
+    <!-- Written by the exporter, then packaged as the raw JSON artifact and bundled into the nupkg/npm archives. -->
+    <generated.json>${project.build.directory}/generated-resources/secret-patterns.json</generated.json>
+    <version.exec.plugin>3.2.0</version.exec.plugin>
+    <version.build-helper.plugin>3.6.1</version.build-helper.plugin>
+  </properties>
+
+  <dependencies>
+    <!-- COMPILE -->
+    <dependency>
+      <groupId>org.sonarsource.analyzer-commons</groupId>
+      <artifactId>sonar-analyzer-commons</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+
+    <!-- TEST -->
+    <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- 1. generate-resources is too early (before compile); generate the JSON at prepare-package,
+           after the exporter and its dependencies are compiled. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>${version.exec.plugin}</version>
+        <executions>
+          <execution>
+            <id>generate-secret-patterns-json</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>${exporter.mainClass}</mainClass>
+              <arguments>
+                <argument>${generated.json}</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- 2. Filter the NuGet/npm manifest templates with the resolved ${package.version}. Templates live outside
+           src/main/resources so they are not copied into the (unpublished) helper jar. -->
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>filter-packaging-templates</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/packaging</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/src/main/packaging</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+              <!-- Keep dotfiles such as _rels/.rels, required by the OPC (.nupkg) layout. -->
+              <useDefaultExcludes>false</useDefaultExcludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- 3. Assemble the .nupkg (OPC zip) and npm .tgz (tar.gz) into target/. These are NOT Maven artifacts: the
+           .nupkg is signed and pushed to the Repox NuGet feed by the CI workflow, which reads it straight from
+           target/ (see .github/workflows/build.yml). Only the raw JSON is attached to the Maven reactor below. -->
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>build-configuration-packages</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <!-- Not attached to the reactor: distributed via the NuGet feed / (future) npm registry, not Maven. -->
+              <attach>false</attach>
+              <descriptors>
+                <descriptor>src/main/assembly/nupkg.xml</descriptor>
+                <descriptor>src/main/assembly/npm.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- 4. Derive ${package.version} (initialize) and attach the raw JSON as a Maven artifact (package). The
+           .nupkg/.tgz are intentionally not attached here - they are published outside Maven (NuGet feed / npm). -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${version.build-helper.plugin}</version>
+        <executions>
+          <execution>
+            <id>strip-snapshot-for-package-version</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>package.version</name>
+              <value>${project.version}</value>
+              <regex>-SNAPSHOT$</regex>
+              <replacement></replacement>
+              <failIfNoMatch>false</failIfNoMatch>
+            </configuration>
+          </execution>
+          <execution>
+            <id>attach-configuration-artifacts</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${generated.json}</file>
+                  <type>json</type>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/sonar-analyzer-commons-configurations/src/main/assembly/npm.xml
+++ b/sonar-analyzer-commons-configurations/src/main/assembly/npm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 http://maven.apache.org/xsd/assembly-2.2.0.xsd">
+  <!-- An npm package is a gzipped tar whose entries all live under a top-level "package/" directory.
+       build-helper re-attaches the produced .tar.gz with type=tgz. -->
+  <id>npm</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <files>
+    <file>
+      <source>${project.build.directory}/packaging/npm/package.json</source>
+      <outputDirectory>package</outputDirectory>
+      <destName>package.json</destName>
+    </file>
+    <file>
+      <source>${project.build.directory}/generated-resources/secret-patterns.json</source>
+      <outputDirectory>package</outputDirectory>
+      <destName>secret-patterns.json</destName>
+    </file>
+  </files>
+</assembly>

--- a/sonar-analyzer-commons-configurations/src/main/assembly/nupkg.xml
+++ b/sonar-analyzer-commons-configurations/src/main/assembly/nupkg.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 http://maven.apache.org/xsd/assembly-2.2.0.xsd">
+  <!-- A .nupkg is an OPC (zip) package. build-helper re-attaches the produced .zip with type=nupkg. -->
+  <id>nupkg</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <files>
+    <file>
+      <source>${project.build.directory}/packaging/nuget/[Content_Types].xml</source>
+      <outputDirectory>./</outputDirectory>
+      <destName>[Content_Types].xml</destName>
+    </file>
+    <file>
+      <source>${project.build.directory}/packaging/nuget/_rels/.rels</source>
+      <outputDirectory>_rels</outputDirectory>
+      <destName>.rels</destName>
+    </file>
+    <file>
+      <source>${project.build.directory}/packaging/nuget/sonar-analyzer-commons-configurations.nuspec</source>
+      <outputDirectory>./</outputDirectory>
+      <destName>sonar-analyzer-commons-configurations.nuspec</destName>
+    </file>
+    <file>
+      <source>${project.build.directory}/packaging/nuget/package/services/metadata/core-properties/secretpatterns.psmdcp</source>
+      <outputDirectory>package/services/metadata/core-properties</outputDirectory>
+      <destName>secretpatterns.psmdcp</destName>
+    </file>
+    <file>
+      <source>${project.build.directory}/generated-resources/secret-patterns.json</source>
+      <outputDirectory>content</outputDirectory>
+      <destName>secret-patterns.json</destName>
+    </file>
+  </files>
+</assembly>

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslator.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslator.java
@@ -1,0 +1,282 @@
+/*
+ * SonarSource Analyzers Commons Configurations
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.analyzer.commons.appsec.export;
+
+import org.sonarsource.analyzer.commons.appsec.SecretClassifier;
+
+public class RegexTranslator {
+
+  /**
+   * Rewrites possessive quantifiers to atomic groups so the regex is valid .NET while keeping
+   * the exact same matching semantics: {@code X*+ -> (?>X*)}, {@code X++ -> (?>X+)}, {@code X?+ -> (?>X?)},
+   * {@code X{n,m}+ -> (?>X{n,m})}. Named groups {@code (?<name>…)} and backrefs {@code \k<name>} are .NET-compatible
+   * and pass through unchanged. Greedy/lazy quantifiers are preserved.
+   *
+   * @throws IllegalArgumentException if the regex uses a Java-only construct this translator cannot faithfully
+   *   render for .NET (see {@link #rejectUnsupportedConstructs(String)}).
+   */
+  static String toPortableRegex(String regex) {
+    rejectUnsupportedConstructs(regex);
+    StringBuilder out = new StringBuilder();
+    int i = 0;
+    int n = regex.length();
+    while (i < n) {
+      char c = regex.charAt(i);
+      // Anchors and alternation are not quantifiable atoms: copy them verbatim.
+      if (c == '^' || c == '$' || c == '|') {
+        out.append(c);
+        i++;
+        continue;
+      }
+      String atom;
+      if (c == '\\') {
+        int end = readEscape(regex, i);
+        atom = regex.substring(i, end);
+        i = end;
+      } else if (c == '[') {
+        int end = readClassEnd(regex, i);
+        atom = regex.substring(i, end);
+        i = end;
+      } else if (c == '(') {
+        atom = translateGroup(regex, i);
+        i = matchingParen(regex, i) + 1;
+      } else {
+        atom = String.valueOf(c);
+        i++;
+      }
+      RegexTranslator.Quantifier q = readQuantifier(regex, i);
+      if (q == null) {
+        out.append(atom);
+      } else {
+        i = q.next;
+        if (q.possessive) {
+          out.append("(?>").append(atom).append(q.base).append(')');
+        } else {
+          out.append(atom).append(q.base);
+          if (q.lazy) {
+            out.append('?');
+          }
+        }
+      }
+    }
+    return out.toString();
+  }
+
+  /**
+   * Fails fast on Java regex constructs that {@link #toPortableRegex(String)} cannot faithfully render for the
+   * .NET dialects consumed by non-JVM analyzers. No current {@link SecretClassifier} pattern uses these, so
+   * this is a guard against a future pattern being exported as a silently wrong regex rather than a live bug:
+   * <ul>
+   *   <li>{@code \Q...\E} literal quoting — unsupported by .NET, JS and RE2;</li>
+   *   <li>{@code \x{...}} variable-length hex escapes — .NET/JS spell these differently with unicode escapes, while
+   *       the two-digit {@code \xHH} form stays portable and is left untouched;</li>
+   *   <li>{@code \0nn} octal escapes — not portably supported;</li>
+   *   <li>{@code \R} linebreak, {@code \h}/{@code \H}/{@code \v}/{@code \V} horizontal/vertical whitespace classes,
+   *       {@code \X} grapheme cluster and {@code \G} end-of-previous-match anchor — Java-only; {@code \v} additionally
+   *       clashes with the single vertical-tab it denotes in .NET/JS;</li>
+   *   <li>{@code \b{g}} grapheme boundary — Java-only, while the plain {@code \b} word boundary stays portable.</li>
+   * </ul>
+   * The scan is a deliberately simple pass over escape tokens, independent of the translation parser so the two do
+   * not share bugs. Every backslash escapes exactly the next character, so {@code \\Q} (an escaped backslash then a
+   * literal {@code Q}) is correctly left alone.
+   */
+  private static void rejectUnsupportedConstructs(String regex) {
+    int n = regex.length();
+    int i = 0;
+    while (i < n) {
+      if (regex.charAt(i) != '\\' || i + 1 >= n) {
+        i++;
+        continue;
+      }
+      char d = regex.charAt(i + 1);
+      switch (d) {
+        case 'Q':
+        case 'E':
+          throw unsupportedConstruct("\\Q...\\E literal quoting", regex);
+        case '0':
+          throw unsupportedConstruct("\\0nn octal escape", regex);
+        case 'R':
+          throw unsupportedConstruct("\\R linebreak matcher", regex);
+        case 'h':
+        case 'H':
+          throw unsupportedConstruct("\\h / \\H horizontal-whitespace class", regex);
+        case 'v':
+        case 'V':
+          throw unsupportedConstruct("\\v / \\V vertical-whitespace class", regex);
+        case 'X':
+          throw unsupportedConstruct("\\X grapheme cluster", regex);
+        case 'G':
+          throw unsupportedConstruct("\\G end-of-previous-match anchor", regex);
+        default:
+          break;
+      }
+      if (d == 'x' && i + 2 < n && regex.charAt(i + 2) == '{') {
+        throw unsupportedConstruct("\\x{...} variable-length hex escape", regex);
+      }
+      // Plain \b is a portable word boundary; only the Java \b{g} grapheme boundary is rejected.
+      if (d == 'b' && i + 2 < n && regex.charAt(i + 2) == '{') {
+        throw unsupportedConstruct("\\b{g} grapheme boundary", regex);
+      }
+      i += 2;
+    }
+  }
+
+  private static IllegalArgumentException unsupportedConstruct(String construct, String regex) {
+    return new IllegalArgumentException(
+      "Cannot export a .NET-portable regex: unsupported construct " + construct + " in pattern: " + regex);
+  }
+
+  /** Returns the index just past the escape token starting at {@code i} (which points at a backslash). */
+  private static int readEscape(String re, int i) {
+    if (i + 1 >= re.length()) {
+      return i + 1;
+    }
+    char d = re.charAt(i + 1);
+    if (d == 'k' && i + 2 < re.length() && re.charAt(i + 2) == '<') {
+      return re.indexOf('>', i + 2) + 1;
+    }
+    if ((d == 'p' || d == 'P') && i + 2 < re.length() && re.charAt(i + 2) == '{') {
+      return re.indexOf('}', i + 2) + 1;
+    }
+    return i + 2;
+  }
+
+  /** Reconstructs the group at {@code i} with its body translated, so nested possessive quantifiers are rewritten. */
+  private static String translateGroup(String re, int i) {
+    int bodyStart;
+    if (re.startsWith("(?", i)) {
+      if (re.startsWith("(?<=", i) || re.startsWith("(?<!", i)) {
+        bodyStart = i + 4;
+      } else if (re.startsWith("(?<", i)) {
+        // Named group (?<name>… ; body starts after the closing '>'.
+        bodyStart = re.indexOf('>', i + 2) + 1;
+      } else {
+        // (?:  (?=  (?!  (?>
+        bodyStart = i + 3;
+      }
+    } else {
+      bodyStart = i + 1;
+    }
+    int close = matchingParen(re, i);
+    String prefix = re.substring(i, bodyStart);
+    String body = re.substring(bodyStart, close);
+    return prefix + toPortableRegex(body) + ")";
+  }
+  /** Returns the index of the {@code )} matching the {@code (} at {@code open}, accounting for classes and escapes. */
+  private static int matchingParen(String re, int open) {
+    int depth = 0;
+    int i = open;
+    int n = re.length();
+    while (i < n) {
+      char c = re.charAt(i);
+      if (c == '\\') {
+        i += 2;
+      } else if (c == '[') {
+        i = readClassEnd(re, i);
+      } else if (c == '(') {
+        depth++;
+        i++;
+      } else if (c == ')') {
+        depth--;
+        if (depth == 0) {
+          return i;
+        }
+        i++;
+      } else {
+        i++;
+      }
+    }
+    throw new IllegalStateException("Unbalanced parentheses in regex: " + re);
+  }
+
+  /** Returns the index just past the closing {@code ]} of the character class starting at {@code i}. */
+  private static int readClassEnd(String re, int i) {
+    int n = re.length();
+    int j = i + 1;
+    if (j < n && re.charAt(j) == '^') {
+      j++;
+    }
+    // A ']' immediately after '[' or '[^' is a literal, not the terminator.
+    if (j < n && re.charAt(j) == ']') {
+      j++;
+    }
+    while (j < n) {
+      char c = re.charAt(j);
+      if (c == '\\') {
+        j += 2;
+      } else if (c == ']') {
+        return j + 1;
+      } else {
+        j++;
+      }
+    }
+    return n;
+  }
+  
+  /** Reads an optional quantifier at {@code i}. Returns {@code null} if there is none. */
+  private static RegexTranslator.Quantifier readQuantifier(String re, int i) {
+    int n = re.length();
+    if (i >= n) {
+      return null;
+    }
+    char c = re.charAt(i);
+    String base;
+    int after;
+    if (c == '*' || c == '+' || c == '?') {
+      base = String.valueOf(c);
+      after = i + 1;
+    } else if (c == '{') {
+      int close = re.indexOf('}', i);
+      if (close < 0) {
+        return null;
+      }
+      String content = re.substring(i + 1, close);
+      // Only digit/comma content is a quantifier; anything else means '{' is a literal.
+      if (!content.matches("\\d+(,\\d*)?")) {
+        return null;
+      }
+      base = re.substring(i, close + 1);
+      after = close + 1;
+    } else {
+      return null;
+    }
+    boolean possessive = false;
+    boolean lazy = false;
+    if (after < n && re.charAt(after) == '+') {
+      possessive = true;
+      after++;
+    } else if (after < n && re.charAt(after) == '?') {
+      lazy = true;
+      after++;
+    }
+    return new RegexTranslator.Quantifier(base, possessive, lazy, after);
+  }
+  
+  private static final class Quantifier {
+    private final String base;
+    private final boolean possessive;
+    private final boolean lazy;
+    private final int next;
+
+    private Quantifier(String base, boolean possessive, boolean lazy, int next) {
+      this.base = base;
+      this.possessive = possessive;
+      this.lazy = lazy;
+      this.next = next;
+    }
+  }
+}

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslator.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslator.java
@@ -20,6 +20,10 @@ import org.sonarsource.analyzer.commons.appsec.SecretClassifier;
 
 public class RegexTranslator {
 
+  private RegexTranslator() {
+    // utility class
+  }
+
   /**
    * Rewrites possessive quantifiers to atomic groups so the regex is valid .NET while keeping
    * the exact same matching semantics: {@code X*+ -> (?>X*)}, {@code X++ -> (?>X+)}, {@code X?+ -> (?>X?)},
@@ -104,18 +108,15 @@ public class RegexTranslator {
       }
       char d = regex.charAt(i + 1);
       switch (d) {
-        case 'Q':
-        case 'E':
+        case 'Q', 'E':
           throw unsupportedConstruct("\\Q...\\E literal quoting", regex);
         case '0':
           throw unsupportedConstruct("\\0nn octal escape", regex);
         case 'R':
           throw unsupportedConstruct("\\R linebreak matcher", regex);
-        case 'h':
-        case 'H':
+        case 'h', 'H':
           throw unsupportedConstruct("\\h / \\H horizontal-whitespace class", regex);
-        case 'v':
-        case 'V':
+        case 'v', 'V':
           throw unsupportedConstruct("\\v / \\V vertical-whitespace class", regex);
         case 'X':
           throw unsupportedConstruct("\\X grapheme cluster", regex);

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporter.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporter.java
@@ -114,7 +114,7 @@ public final class SecretPatternsExporter {
   }
 
   private static List<String> translate(List<String> regexes) {
-    return regexes.stream().map(RegexTranslator::toPortableRegex).collect(Collectors.toList());
+    return regexes.stream().map(RegexTranslator::toPortableRegex).toList();
   }
 
   /** Visible for testing: confirms the exporter's output is a compilable Java regex too. */

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporter.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporter.java
@@ -1,0 +1,125 @@
+/*
+ * SonarSource Analyzers Commons Configurations
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.analyzer.commons.appsec.export;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.sonarsource.analyzer.commons.appsec.SecretClassifier;
+
+/**
+ * Generates the machine-readable JSON export of {@link SecretClassifier}'s secret-exclusion patterns, the single
+ * source of truth shared with non-JVM analyzers (SonarJS, sonar-dotnet, …).
+ *
+ * <p>The JVM classifier keeps its possessive quantifiers for performance; on export they are rewritten to the
+ * semantically identical atomic groups ({@code X++} &rarr; {@code (?>X+)}), which .NET supports and possessive
+ * quantifiers do not. See {@link RegexTranslator#toPortableRegex(String)}.
+ *
+ * <p>Output is deterministic and pretty-printed so the artifact diffs cleanly. Run via {@code exec:java} at build time;
+ * {@code main} takes the target file path as its single argument.
+ */
+public final class SecretPatternsExporter {
+
+  private static final String DESCRIPTION = "Secret-exclusion patterns generated from SecretClassifier in " +
+    "sonar-analyzer-commons. Do not edit by hand. Regexes are applied case-insensitively with \"find\" " +
+    "(search-anywhere) semantics; exact values are matched in full, case-insensitively.";
+
+  private static final Gson GSON = new GsonBuilder()
+    .setPrettyPrinting()
+    .disableHtmlEscaping()
+    .create();
+
+  private SecretPatternsExporter() {
+  }
+
+  public static void main(String[] args) {
+    if (args.length < 1) {
+      throw new IllegalArgumentException("Usage: SecretPatternsExporter <output-json-path>");
+    }
+    Path output = Paths.get(args[0]).toAbsolutePath();
+    try {
+      Files.createDirectories(output.getParent());
+      Files.write(output, toJson().getBytes(StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /**
+   * Builds the JSON document from the classifier's exported patterns, translating each regex to a .NET-portable form.
+   */
+  public static String toJson() {
+    JsonObject root = new JsonObject();
+    root.addProperty("description", DESCRIPTION);
+
+    JsonObject regex = new JsonObject();
+    regex.addProperty("semantics", "find");
+    regex.addProperty("caseInsensitive", true);
+    JsonObject exact = new JsonObject();
+    exact.addProperty("caseInsensitive", true);
+    JsonObject match = new JsonObject();
+    match.add("regex", regex);
+    match.add("exact", exact);
+    root.add("match", match);
+
+    JsonArray patternGroups = new JsonArray();
+    for (SecretClassifier.PatternGroupView group : SecretClassifier.exportPatternGroups()) {
+      JsonObject json = new JsonObject();
+      json.addProperty("category", group.category());
+      json.add("patterns", toArray(translate(group.regexes())));
+      patternGroups.add(json);
+    }
+    root.add("patternGroups", patternGroups);
+
+    JsonArray exactMatchGroups = new JsonArray();
+    for (SecretClassifier.ExactMatchGroupView group : SecretClassifier.exportExactMatchGroups()) {
+      JsonObject json = new JsonObject();
+      json.addProperty("category", group.category());
+      json.add("values", toArray(group.values()));
+      exactMatchGroups.add(json);
+    }
+    root.add("exactMatchGroups", exactMatchGroups);
+
+    return GSON.toJson(root) + "\n";
+  }
+
+  private static JsonArray toArray(List<String> values) {
+    JsonArray array = new JsonArray();
+    values.forEach(array::add);
+    return array;
+  }
+
+  private static List<String> translate(List<String> regexes) {
+    return regexes.stream().map(RegexTranslator::toPortableRegex).collect(Collectors.toList());
+  }
+
+  /** Visible for testing: confirms the exporter's output is a compilable Java regex too. */
+  static Pattern compilePortable(String regex) {
+    return Pattern.compile(RegexTranslator.toPortableRegex(regex), Pattern.CASE_INSENSITIVE);
+  }
+
+}

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporter.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporter.java
@@ -28,7 +28,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.sonarsource.analyzer.commons.appsec.SecretClassifier;
 
 /**

--- a/sonar-analyzer-commons-configurations/src/main/packaging/npm/package.json
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/npm/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@sonarsource/analyzer-commons-configurations",
+  "version": "${package.version}",
+  "description": "Shared analyzer configuration data (secret-exclusion regexes) generated from the sonar-analyzer-commons SecretClassifier, for use by non-JVM SonarSource analyzers.",
+  "license": "LGPL-3.0-only",
+  "files": [
+    "secret-patterns.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SonarSource/sonar-analyzer-commons.git"
+  }
+}

--- a/sonar-analyzer-commons-configurations/src/main/packaging/nuget/[Content_Types].xml
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/nuget/[Content_Types].xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />
+  <Default Extension="psmdcp" ContentType="application/vnd.openxmlformats-package.core-properties+xml" />
+  <Default Extension="nuspec" ContentType="application/octet" />
+  <Default Extension="json" ContentType="application/json" />
+</Types>

--- a/sonar-analyzer-commons-configurations/src/main/packaging/nuget/_rels/.rels
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/nuget/_rels/.rels
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Type="http://schemas.microsoft.com/packaging/2010/07/manifest" Target="/sonar-analyzer-commons-configurations.nuspec" Id="Rel1" />
+  <Relationship Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="/package/services/metadata/core-properties/secretpatterns.psmdcp" Id="Rel2" />
+</Relationships>

--- a/sonar-analyzer-commons-configurations/src/main/packaging/nuget/package/services/metadata/core-properties/secretpatterns.psmdcp
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/nuget/package/services/metadata/core-properties/secretpatterns.psmdcp
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coreProperties
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://schemas.openxmlformats.org/package/2006/metadata/core-properties">
+  <dc:creator>SonarSource</dc:creator>
+  <dc:description>Shared analyzer configuration data generated from sonar-analyzer-commons.</dc:description>
+  <dc:identifier>SonarAnalyzer.CommonsConfigurations</dc:identifier>
+  <version>${package.version}</version>
+  <keywords>sonarsource analyzer secrets configuration</keywords>
+  <lastModifiedBy>sonar-analyzer-commons build</lastModifiedBy>
+</coreProperties>

--- a/sonar-analyzer-commons-configurations/src/main/packaging/nuget/sonar-analyzer-commons-configurations.nuspec
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/nuget/sonar-analyzer-commons-configurations.nuspec
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>SonarAnalyzer.CommonsConfigurations</id>
+    <version>${package.version}</version>
+    <authors>SonarSource</authors>
+    <owners>SonarSource</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">LGPL-3.0-only</license>
+    <projectUrl>https://github.com/SonarSource/sonar-analyzer-commons</projectUrl>
+    <description>Shared analyzer configuration data (secret-exclusion regexes) generated from the sonar-analyzer-commons
+      SecretClassifier, for use by non-JVM SonarSource analyzers. The payload is content/secret-patterns.json.</description>
+    <tags>sonarsource analyzer secrets configuration</tags>
+  </metadata>
+</package>

--- a/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslatorTest.java
+++ b/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslatorTest.java
@@ -196,6 +196,6 @@ class RegexTranslatorTest {
   private static List<String> sourceRegexes() {
     return SecretClassifier.exportPatternGroups().stream()
       .flatMap(group -> group.regexes().stream())
-      .collect(java.util.stream.Collectors.toList());
+      .toList();
   }
 }

--- a/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslatorTest.java
+++ b/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslatorTest.java
@@ -1,0 +1,201 @@
+/*
+ * SonarSource Analyzers Commons Configurations
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.analyzer.commons.appsec.export;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.sonarsource.analyzer.commons.appsec.SecretClassifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RegexTranslatorTest {
+  private static final List<String> SAMPLES = List.of(
+    "", "abc", "samplepassword", "EXAMPLE_SECRET", "deadbeef", "qwerty",
+    "password1234", "passwd", "undefined", "true", "null", "yourpassword",
+    "abbbbc", "111111", "1fj28...askn3i", "TODO: replace me", "FIXME",
+    "admin123", "vncpass", "super-secret-p4ssw0rd",
+    "hunter2", "letmein", "abc123", "changeme", "changeit", "unknown", "optional",
+    "enabled", "disabled", "string", "random", "token",
+    "${secret}", "value-${pwd}", "#{{secret}}", "((db-password))",
+    "$(echo $PASSWORD)", "`echo $PASSWORD`", "$foo_bar",
+    "{secret}", "%{secret}", "{{secret}}",
+    "System.getenv(\"secret\")", "process.env.MY_SECRET", "%GITHUB_TOKEN%", "config['secret']", "Read-Host",
+    "<password>", "(password)", "[password]", "%(password)s", "@variables('name')",
+    "encrypted:YWJjZGVm", "{cipher}1e3faa2cdab2deae117dca102e52922a", "enc[QUJDRA==]", "ENC{abcdef}",
+    "%enc{QUJDRA==}", "ENC(abcdef)",
+    "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-pass", "op://vault/item/password",
+    "VAULT[path/to/secret access_token]",
+    "/var/keys/gsa-key.json", "v1.2.3", ">=1.0.0", "~1.4.5-alpha", "4.0.9(@types/node@22.13.4)",
+    // realistic values that should NOT be excluded
+    "Xk9Lm2Qp7Rs4Tv1Wz0", "9f8e7d6c5b4a392817", "Tr0ub4dor&3xpl0!t", "mytoken123", "this_should_remain_unknown");
+
+  static Stream<Arguments> translationCases() {
+    return Stream.of(
+      // possessive quantifiers become atomic groups
+      Arguments.of("a++", "(?>a+)"),
+      Arguments.of("a*+", "(?>a*)"),
+      Arguments.of("a?+", "(?>a?)"),
+      Arguments.of("[^}]++", "(?>[^}]+)"),
+      Arguments.of("\\d{0,5}+", "(?>\\d{0,5})"),
+      Arguments.of("\\k<repeated>*+", "(?>\\k<repeated>*)"),
+      // nested possessive quantifiers, inner and outer both rewritten
+      Arguments.of("(?:/[a-z0-9_.-]++){3,}+", "(?>(?:/(?>[a-z0-9_.-]+)){3,})"),
+      // escaped delimiters around a possessive negated class
+      Arguments.of("^%?\\{[^}]++\\}$", "^%?\\{(?>[^}]+)\\}$"),
+      // greedy / lazy / fixed quantifiers are preserved
+      Arguments.of("a+", "a+"),
+      Arguments.of("a+?", "a+?"),
+      Arguments.of("a{2,3}", "a{2,3}"),
+      // named groups and backreferences pass through unchanged (no possessive quantifiers)
+      Arguments.of("(?<char>[\\w\\*\\.])\\k<char>{3}", "(?<char>[\\w\\*\\.])\\k<char>{3}"),
+      // escaped '+' is a literal, not a possessive marker
+      Arguments.of("a\\+b", "a\\+b"),
+      // a literal '{' (not a valid quantifier) is left alone
+      Arguments.of("a{b}", "a{b}"),
+      // the two-digit \xHH hex escape is portable to .NET and passes through unchanged
+      Arguments.of("\\x41", "\\x41"),
+      // the plain \b word boundary and \B non-boundary are portable and pass through unchanged
+      Arguments.of("\\bword\\b", "\\bword\\b"),
+      Arguments.of("\\Bfoo", "\\Bfoo"),
+      // an escaped backslash followed by 'Q' is a literal, not the start of \Q...\E quoting
+      Arguments.of("a\\\\Qb", "a\\\\Qb"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("translationCases")
+  void shouldTranslatePossessiveQuantifiersToAtomicGroups(String input, String expected) {
+    assertThat(RegexTranslator.toPortableRegex(input)).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> unsupportedConstructs() {
+    return Stream.of(
+      // \Q...\E literal quoting is unsupported by .NET
+      Arguments.of("a\\Qliteral.\\Eb", "\\Q...\\E literal quoting"),
+      Arguments.of("\\Efoo", "\\Q...\\E literal quoting"),
+      // \x{...} variable-length hex is spelled differently across engines; the parser would otherwise corrupt it
+      Arguments.of("\\x{1F600}", "\\x{...} variable-length hex escape"),
+      Arguments.of("[\\x{41}]", "\\x{...} variable-length hex escape"),
+      // \0nn octal escapes are not portably supported
+      Arguments.of("\\012", "\\0nn octal escape"),
+      // Java-only linebreak / whitespace / grapheme / anchor escapes with no portable .NET equivalent
+      Arguments.of("a\\Rb", "\\R linebreak matcher"),
+      Arguments.of("\\h+", "\\h / \\H horizontal-whitespace class"),
+      Arguments.of("\\H", "\\h / \\H horizontal-whitespace class"),
+      Arguments.of("\\v", "\\v / \\V vertical-whitespace class"),
+      Arguments.of("[\\V]", "\\v / \\V vertical-whitespace class"),
+      Arguments.of("\\X", "\\X grapheme cluster"),
+      Arguments.of("\\Gfoo", "\\G end-of-previous-match anchor"),
+      // \b{g} grapheme boundary is Java-only (plain \b stays portable)
+      Arguments.of("foo\\b{g}bar", "\\b{g} grapheme boundary"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("unsupportedConstructs")
+  void shouldRejectConstructsThatCannotBeTranslatedPortably(String input, String messageFragment) {
+    assertThatThrownBy(() -> RegexTranslator.toPortableRegex(input))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining(messageFragment)
+      .hasMessageContaining(input);
+  }
+
+  @Test
+  void exportedPatternsShouldContainNoPossessiveQuantifiers() {
+    for (String regex : sourceRegexes()) {
+      String portable = RegexTranslator.toPortableRegex(regex);
+      assertThat(hasPossessiveQuantifier(portable))
+        .as("possessive quantifier remains in translated pattern: %s (from %s)", portable, regex)
+        .isFalse();
+    }
+  }
+
+  @Test
+  void exportedPatternsShouldStillCompileAsRegex() {
+    for (String regex : sourceRegexes()) {
+      assertThat(SecretPatternsExporter.compilePortable(regex))
+        .as("translated pattern does not compile: %s", regex)
+        .isNotNull();
+    }
+  }
+
+  @Test
+  void translationShouldBeIdempotent() {
+    for (String regex : sourceRegexes()) {
+      String once = RegexTranslator.toPortableRegex(regex);
+      assertThat(RegexTranslator.toPortableRegex(once)).isEqualTo(once);
+    }
+  }
+
+
+  @Test
+  void translatedPatternsShouldMatchTheSameSamplesAsTheSource() {
+    for (String regex : sourceRegexes()) {
+      Pattern source = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+      Pattern portable = SecretPatternsExporter.compilePortable(regex);
+      for (String sample : SAMPLES) {
+        assertThat(portable.matcher(sample).find())
+          .as("translation changed matching of \"%s\" for pattern %s", sample, regex)
+          .isEqualTo(source.matcher(sample).find());
+      }
+    }
+  }
+
+  /**
+   * Independent detector of possessive quantifiers (a quantifier immediately followed by {@code +}), skipping escapes
+   * and character-class contents. Deliberately simpler than the exporter's parser so the two do not share bugs.
+   */
+  private static boolean hasPossessiveQuantifier(String re) {
+    int n = re.length();
+    boolean inClass = false;
+    int i = 0;
+    while (i < n) {
+      char c = re.charAt(i);
+      if (c == '\\') {
+        i += 2;
+        continue;
+      }
+      if (inClass) {
+        if (c == ']') {
+          inClass = false;
+        }
+        i++;
+        continue;
+      }
+      if (c == '[') {
+        inClass = true;
+        i++;
+        continue;
+      }
+      if ((c == '*' || c == '+' || c == '?' || c == '}') && i + 1 < n && re.charAt(i + 1) == '+') {
+        return true;
+      }
+      i++;
+    }
+    return false;
+  }
+
+  private static List<String> sourceRegexes() {
+    return SecretClassifier.exportPatternGroups().stream()
+      .flatMap(group -> group.regexes().stream())
+      .collect(java.util.stream.Collectors.toList());
+  }
+}

--- a/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporterTest.java
+++ b/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporterTest.java
@@ -62,9 +62,10 @@ class SecretPatternsExporterTest {
     // Parses back to a single JSON object.
     assertThat(new JSONParser().parse(json)).isInstanceOf(JSONObject.class);
     // Deterministic artifact that diffs cleanly: pretty-printed (indented, multi-line) and newline-terminated.
-    assertThat(json).startsWith("{\n");
-    assertThat(json).contains("\n  \"");
-    assertThat(json).endsWith("}\n");
+    assertThat(json)
+      .startsWith("{\n")
+      .contains("\n  \"")
+      .endsWith("}\n");
     assertThat(json.lines().count()).isGreaterThan(1);
   }
 

--- a/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporterTest.java
+++ b/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporterTest.java
@@ -1,0 +1,106 @@
+/*
+ * SonarSource Analyzers Commons Configurations
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.analyzer.commons.appsec.export;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Covers the exporter's own responsibilities: turning {@link org.sonarsource.analyzer.commons.appsec.SecretClassifier}
+ * into a well-formed, portable JSON document and writing it to disk. The regex-translation behaviour lives in
+ * {@link RegexTranslator} and is exercised by {@code RegexTranslatorTest}; the JSON-content mirroring is covered by
+ * {@code SecretPatternsJsonTest}.
+ */
+class SecretPatternsExporterTest {
+
+  @Test
+  void mainShouldWriteJsonToTheGivenPathCreatingMissingParents(@TempDir Path tempDir) throws IOException {
+    // The parent directory does not exist yet, so main() must create it (as it does under target/ at build time).
+    Path output = tempDir.resolve("generated-resources").resolve("secret-patterns.json");
+
+    SecretPatternsExporter.main(new String[] {output.toString()});
+
+    assertThat(output).exists();
+    assertThat(Files.readString(output)).isEqualTo(SecretPatternsExporter.toJson());
+  }
+
+  @Test
+  void mainShouldFailWhenNoOutputPathIsGiven() {
+    assertThatThrownBy(() -> SecretPatternsExporter.main(new String[0]))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Usage");
+  }
+
+  @Test
+  void jsonShouldBeWellFormedAndPrettyPrinted() throws ParseException {
+    String json = SecretPatternsExporter.toJson();
+
+    // Parses back to a single JSON object.
+    assertThat(new JSONParser().parse(json)).isInstanceOf(JSONObject.class);
+    // Deterministic artifact that diffs cleanly: pretty-printed (indented, multi-line) and newline-terminated.
+    assertThat(json).startsWith("{\n");
+    assertThat(json).contains("\n  \"");
+    assertThat(json).endsWith("}\n");
+    assertThat(json.lines().count()).isGreaterThan(1);
+  }
+
+  @Test
+  void jsonShouldExposeTheExpectedTopLevelStructure() throws ParseException {
+    JSONObject root = parse();
+
+    assertThat(root).containsOnlyKeys("description", "match", "patternGroups", "exactMatchGroups");
+    assertThat(root.get("description")).asString().contains("Do not edit by hand");
+    assertThat((JSONArray) root.get("patternGroups")).isNotEmpty();
+    assertThat((JSONArray) root.get("exactMatchGroups")).isNotEmpty();
+  }
+
+  @Test
+  void everyExportedPatternShouldBeFullyTranslatedAndCompile() throws ParseException {
+    JSONArray patternGroups = (JSONArray) parse().get("patternGroups");
+
+    assertThat(patternGroups).isNotEmpty();
+    for (Object groupObj : patternGroups) {
+      JSONObject group = (JSONObject) groupObj;
+      assertThat(group).containsKeys("category", "patterns");
+      for (Object patternObj : (JSONArray) group.get("patterns")) {
+        String pattern = (String) patternObj;
+        // The emitted regex is already portable: re-translating it is a no-op (fixed point).
+        assertThat(RegexTranslator.toPortableRegex(pattern))
+          .as("exported pattern is not fully translated: %s", pattern)
+          .isEqualTo(pattern);
+        // ...and it is a regex the .NET-portable form still compiles as Java too.
+        assertThat(SecretPatternsExporter.compilePortable(pattern))
+          .as("exported pattern does not compile: %s", pattern)
+          .isNotNull();
+      }
+    }
+  }
+
+  private static JSONObject parse() throws ParseException {
+    return (JSONObject) new JSONParser().parse(SecretPatternsExporter.toJson());
+  }
+}

--- a/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsJsonTest.java
+++ b/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsJsonTest.java
@@ -1,0 +1,82 @@
+/*
+ * SonarSource Analyzers Commons Configurations
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.analyzer.commons.appsec.export;
+
+import java.util.List;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.junit.jupiter.api.Test;
+import org.sonarsource.analyzer.commons.appsec.SecretClassifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecretPatternsJsonTest {
+
+  @Test
+  void jsonShouldBeDeterministic() {
+    assertThat(SecretPatternsExporter.toJson()).isEqualTo(SecretPatternsExporter.toJson());
+  }
+
+  @Test
+  void jsonShouldDeclareMatchSemantics() throws ParseException {
+    JSONObject root = parse();
+    JSONObject match = (JSONObject) root.get("match");
+    JSONObject regex = (JSONObject) match.get("regex");
+    assertThat(regex)
+      .containsEntry("semantics", "find")
+      .containsEntry("caseInsensitive", Boolean.TRUE);
+    assertThat((JSONObject) match.get("exact")).containsEntry("caseInsensitive", Boolean.TRUE);
+    assertThat(root.get("description")).asString().contains("SecretClassifier");
+  }
+
+  @Test
+  void patternGroupsShouldMirrorSecretClassifierWithPortableRegexes() throws ParseException {
+    JSONArray groups = (JSONArray) parse().get("patternGroups");
+    List<SecretClassifier.PatternGroupView> source = SecretClassifier.exportPatternGroups();
+    assertThat(groups).hasSameSizeAs(source);
+    for (int i = 0; i < source.size(); i++) {
+      JSONObject group = (JSONObject) groups.get(i);
+      SecretClassifier.PatternGroupView expected = source.get(i);
+      assertThat(group).containsEntry("category", expected.category());
+      JSONArray patterns = (JSONArray) group.get("patterns");
+      assertThat(patterns).hasSameSizeAs(expected.regexes());
+      for (int j = 0; j < expected.regexes().size(); j++) {
+        assertThat(patterns.get(j)).isEqualTo(RegexTranslator.toPortableRegex(expected.regexes().get(j)));
+      }
+    }
+  }
+
+  @Test
+  void exactMatchGroupsShouldMirrorSecretClassifier() throws ParseException {
+    JSONArray groups = (JSONArray) parse().get("exactMatchGroups");
+    List<SecretClassifier.ExactMatchGroupView> source = SecretClassifier.exportExactMatchGroups();
+    assertThat(groups).hasSameSizeAs(source);
+    for (int i = 0; i < source.size(); i++) {
+      JSONObject group = (JSONObject) groups.get(i);
+      SecretClassifier.ExactMatchGroupView expected = source.get(i);
+      assertThat(group).containsEntry("category", expected.category());
+
+      assertThat((JSONArray) group.get("values")).containsExactlyElementsOf(expected.values());
+    }
+  }
+
+  private static JSONObject parse() throws ParseException {
+    return (JSONObject) new JSONParser().parse(SecretPatternsExporter.toJson());
+  }
+}


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **New module:**
  - Added `sonar-analyzer-commons-configurations` to export `SecretClassifier` patterns as a machine-readable JSON file.
  - Implemented `SecretPatternsExporter` to convert Java regexes to .NET-compatible atomic groups.
- **Packaging:**
  - Configured build to generate and bundle the JSON patterns into both `.nupkg` (NuGet) and `.tar.gz` (npm) formats.
  - Updated root `pom.xml` to include the new module and publish the resulting JSON, nupkg, and tgz artifacts.
- **API changes:**
  - Added `exportPatternGroups()` and `exportExactMatchGroups()` to `SecretClassifier` for external consumption of classification logic.


<sub>This will update automatically on new commits.</sub>