### PR TITLE
ACOMMONS-80 Update Java to 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,10 +82,9 @@
     <version.junit-jupiter>5.8.1</version.junit-jupiter>
     <!-- used for deployment to SonarSource Artifactory -->
     <gitRepositoryName>sonar-analyzer-commons</gitRepositoryName>
-    <maven.compiler.release>8</maven.compiler.release>
     <artifactsToPublish>${project.groupId}:sonar-analyzer-commons:jar,${project.groupId}:sonar-analyzer-test-commons:jar,${project.groupId}:sonar-analyzer-recognizers:jar,${project.groupId}:sonar-xml-parsing:jar,${project.groupId}:test-sonar-xml-parsing:jar,${project.groupId}:sonar-regex-parsing:jar</artifactsToPublish>
     <!-- this property configures the settings in parent pom -->
-    <jdk.min.version>11</jdk.min.version>
+    <jdk.min.version>17</jdk.min.version>
     <maven.compiler.release>${jdk.min.version}</maven.compiler.release>
   </properties>
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Build configuration:**
  - Updated `jdk.min.version` from `11` to `17` in `pom.xml`.
  - Set `maven.compiler.release` to use `jdk.min.version` (17) for the project compilation.

<sub>This will update automatically on new commits.</sub>