### PR TITLE
ACOMMONS-3 Add regressions tests

### DIFF
--- a/regex-parsing/src/test/java/org/sonarsource/analyzer/commons/regex/ast/CharacterClassTreeTest.java
+++ b/regex-parsing/src/test/java/org/sonarsource/analyzer/commons/regex/ast/CharacterClassTreeTest.java
@@ -140,6 +140,86 @@ class CharacterClassTreeTest {
     );
   }
 
+  // Regression tests for https://github.com/SonarSource/sonar-analyzer-commons/issues/212 (ACOMMONS-3):
+  // escaped ']' and chained backslashes inside a character class must behave exactly like java.util.regex.Pattern.
+
+  @Test
+  void unclosedClassStartingWithEscapedClosingBracket() {
+    // '[\]' and '[\]a' -> the escaped ']' is a literal character and does not close the class: unclosed, like java.util.regex.Pattern.
+    assertFailParsing("[\\\\]", "Expected ']', but found the end of the regex");
+    assertFailParsing("[\\\\]a", "Expected ']', but found the end of the regex");
+  }
+
+  @Test
+  void classStartingWithEscapedClosingBracket() {
+    // '[\]a]' -> the leading '\]' is a literal ']', followed by 'a', then the class closes normally.
+    RegexTree regex = assertSuccessfulParse("[\\\\]a]");
+    CharacterClassUnionTree union = assertType(CharacterClassUnionTree.class, assertCharacterClass(false, regex));
+    assertListElements(union.getCharacterClasses(),
+      first -> assertCharacter(']', first),
+      second -> assertCharacter('a', second)
+    );
+  }
+
+  @Test
+  void classWithSingleEscapedBackslash() {
+    // '[\\]' -> a single escaped backslash, closes normally.
+    RegexTree regex = assertSuccessfulParse("[\\\\\\\\]");
+    assertCharacter('\\', assertCharacterClass(false, regex));
+  }
+
+  @Test
+  void unclosedClassWithEscapedBackslashThenEscapedClosingBracket() {
+    // '[\\\]' -> escaped backslash, then a literal (escaped) ']' that doesn't close the class: unclosed.
+    assertFailParsing("[\\\\\\\\\\\\]", "Expected ']', but found the end of the regex");
+  }
+
+  @Test
+  void unclosedClassWithEscapedBackslashThenBellEscape() {
+    // '[\\\a' -> escaped backslash, then '\a' (the alert/bell escape), but no closing ']' at all: unclosed.
+    assertFailParsing("[\\\\\\\\\\\\a", "Expected ']', but found the end of the regex");
+  }
+
+  @Test
+  void classWithEscapedBackslashThenBellEscape() {
+    // '[\\\a]' -> escaped backslash, then the alert/bell escape, closes normally.
+    RegexTree regex = assertSuccessfulParse("[\\\\\\\\\\\\a]");
+    CharacterClassUnionTree union = assertType(CharacterClassUnionTree.class, assertCharacterClass(false, regex));
+    assertListElements(union.getCharacterClasses(),
+      first -> assertCharacter('\\', first),
+      second -> assertCharacter('\u0007', second)
+    );
+  }
+
+  @Test
+  void unclosedClassWithEscapedBackslashThenEscapedClosingBracketAndChar() {
+    // '[\\\]a' -> escaped backslash, literal (escaped) ']', then 'a', but never closes: unclosed.
+    assertFailParsing("[\\\\\\\\\\\\]a", "Expected ']', but found the end of the regex");
+  }
+
+  @Test
+  void classWithEscapedBackslashThenEscapedClosingBracketAndChar() {
+    // '[\\\]a]' -> escaped backslash, literal (escaped) ']', 'a', then the class closes normally.
+    RegexTree regex = assertSuccessfulParse("[\\\\\\\\\\\\]a]");
+    CharacterClassUnionTree union = assertType(CharacterClassUnionTree.class, assertCharacterClass(false, regex));
+    assertListElements(union.getCharacterClasses(),
+      first -> assertCharacter('\\', first),
+      second -> assertCharacter(']', second),
+      third -> assertCharacter('a', third)
+    );
+  }
+
+  @Test
+  void classWithTwoEscapedBackslashes() {
+    // '[\\\\]' -> two separate escaped backslashes; both are kept in the AST, none is lost.
+    RegexTree regex = assertSuccessfulParse("[\\\\\\\\\\\\\\\\]");
+    CharacterClassUnionTree union = assertType(CharacterClassUnionTree.class, assertCharacterClass(false, regex));
+    assertListElements(union.getCharacterClasses(),
+      first -> assertCharacter('\\', first),
+      second -> assertCharacter('\\', second)
+    );
+  }
+
   @Test
   void classWithCharacterClassEscapes() {
     RegexTree regex = assertSuccessfulParse("[\\\\w\\\\s]");


### PR DESCRIPTION
## Summary

ACOMMONS-3 (imported from #212) says the regex parser silently turns malformed character class literals into unexpected ASTs. The original report is a list of 10 backslash-heavy strings, each with a `?`/`??`/`???` next to the ones that looked off.

I fed all 10 straight into `RegexParser`, skipping the `JavaCharacterParser` layer that normally unescapes Java string literals before the regex parser ever sees them, and diffed the result against real `java.util.regex.Pattern.compile(...)` on the same strings.

Every one of them matches:

- `[\]`, `[\]a`, `[\\\]`, `[\\\a`, `[\\\]a` come back as unclosed character classes - exactly what `Pattern` does too (it throws `Unclosed character class`).
- `[\]a]`, `[\\]`, `[\\\a]`, `[\\\]a]`, `[\\\\]` parse successfully, and the AST content matches what `Pattern` actually matches.
- The one concrete claim in the report - that `[\\\\]` "loses" a backslash while parsing - doesn't hold up. The AST has two separate escaped-backslash elements, not one.

Worth noting: the report itself admits it's only showing "the first element of the parsing." So whatever debug tool produced these examples was dumping a truncated AST, and that's almost certainly why some correct results looked broken.

I couldn't find an actual bug, so instead of touching parser logic I added one test per reported input, asserting both the resulting AST and the syntax errors. At minimum this locks down these specific edge cases so nobody has to re-litigate them.

## Test plan
- [x] `mvn -o test` in `regex-parsing` - passes, 9 new tests in `CharacterClassTreeTest`
- [x] `mvn -o test` from repo root - `BUILD SUCCESS`, no failures in any module