### PR TITLE
ACOMMONS-1 RuleMetadataLoader ignores fields other than "key" of annotation "org.sonar.check.Rule"

### DIFF
--- a/commons/README.md
+++ b/commons/README.md
@@ -2,7 +2,7 @@ SonarSource Analyzers Commons (compatible with SQ >=7.9)
 =========================
 Logic useful for an average language plugin
 
-* [`RuleMetadataLoader`](./src/main/java/org/sonarsource/analyzer/commons/RuleMetadataLoader.java) - to define rules metadata based on `json` and `html` files
+* [`RuleMetadataLoader`](./src/main/java/org/sonarsource/analyzer/commons/RuleMetadataLoader.java) - to define rules metadata based on `json` and `html` files, or, when constructed without a resource folder, directly from the `org.sonar.check.Rule` annotation
 * [`DeprecatedRuleKey`](./src/main/java/org/sonarsource/analyzer/commons/annotations/DeprecatedRuleKey.java) annotation - when used with [`RuleMetadataLoader`](./src/main/java/org/sonarsource/analyzer/commons/RuleMetadataLoader.java) in will add deprecated rule key for an annotated rule
 * [`BuiltInQualityProfileJsonLoader`](./src/main/java/org/sonarsource/analyzer/commons/BuiltInQualityProfileJsonLoader.java) - to define default rules profiles based on `json` file
 * [`ProfileGenerator`](./src/main/java/org/sonarsource/analyzer/commons/ProfileGenerator.java) - to generate rules profile `xml` file (e.g. can be used for integration tests)

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/RuleMetadataLoader.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/RuleMetadataLoader.java
@@ -79,6 +79,11 @@ public class RuleMetadataLoader {
   private static final String LINEAR_FACTOR = "linearFactor";
   private static final String LINEAR_DESCRIPTION = "linearDesc";
 
+  /**
+   * Without a resource folder, rules added with {@link #addRulesByAnnotatedClass} are described entirely by the
+   * {@code org.sonar.check.Rule} annotation (name, description, priority, tags, status): no JSON/HTML resource file
+   * is read. {@link #addRulesByRuleKey} is not supported in this mode, since it has no annotation to read from.
+   */
   public RuleMetadataLoader(SonarRuntime sonarRuntime) {
     this(null, Collections.emptySet(), sonarRuntime);
   }
@@ -113,8 +118,10 @@ public class RuleMetadataLoader {
 
   private void addRuleByAnnotatedClass(NewRepository repository, Class<?> ruleClass) {
     NewRule rule = addAnnotatedRule(repository, ruleClass);
-    setDescriptionFromHtmlFile(rule);
-    setMetadataFromJsonFile(rule);
+    if (resourceFolder != null) {
+      setDescriptionFromHtmlFile(rule);
+      setMetadataFromJsonFile(rule);
+    }
     setDefaultActivation(rule);
   }
 
@@ -162,6 +169,9 @@ public class RuleMetadataLoader {
   private void addRuleByRuleKey(NewRepository repository, String ruleKey) {
     if (ruleKey.isEmpty()) {
       throw new IllegalStateException("Empty key");
+    }
+    if (resourceFolder == null) {
+      throw new IllegalStateException("Resource folder is required to load a rule by its key: " + ruleKey);
     }
     NewRule rule = repository.createRule(ruleKey);
     setDescriptionFromHtmlFile(rule);

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/RuleMetadataLoaderTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/RuleMetadataLoaderTest.java
@@ -38,6 +38,7 @@ import org.sonar.api.server.rule.RuleParamType;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.NewRepository;
 import org.sonar.api.utils.Version;
+import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 import org.sonarsource.analyzer.commons.domain.RuleManifest;
@@ -457,6 +458,62 @@ public class RuleMetadataLoaderTest {
     List<Class<?>> classes = List.of(TestRule.class);
     assertThrows("Rule not found: S404", IllegalStateException.class,
       () -> ruleMetadataLoader.addRulesByAnnotatedClass(newRepository, classes));
+  }
+
+  @Test
+  public void load_rule_purely_from_annotation_without_resource_folder() {
+    @Rule(
+      key = "MyFirstCustomCheck",
+      name = "Return type and parameter of a method should not be the same",
+      description = "For a method having a single parameter, the types of its return value and its parameter should never be the same.",
+      priority = Priority.CRITICAL,
+      tags = {"bug"})
+    class TestRule {
+    }
+
+    ruleMetadataLoader = new RuleMetadataLoader(SONAR_RUNTIME_9_3);
+    ruleMetadataLoader.addRulesByAnnotatedClass(newRepository, singletonList(TestRule.class));
+    newRepository.done();
+
+    RulesDefinition.Repository repository = context.repository(RULE_REPOSITORY_KEY);
+    RulesDefinition.Rule rule = repository.rule("MyFirstCustomCheck");
+    assertThat(rule).isNotNull();
+    assertThat(rule.name()).isEqualTo("Return type and parameter of a method should not be the same");
+    assertThat(rule.htmlDescription())
+      .isEqualTo("For a method having a single parameter, the types of its return value and its parameter should never be the same.");
+    assertThat(rule.severity()).isEqualTo("CRITICAL");
+    // "bug" is a reserved tag: the SonarQube API converts it into the rule type and removes it from the tag list
+    assertThat(rule.type()).isEqualTo(RuleType.BUG);
+    assertThat(rule.status()).isEqualTo(RuleStatus.READY);
+    assertThat(rule.tags()).isEmpty();
+    assertThat(rule.deprecatedRuleKeys()).isEmpty();
+  }
+
+  @Test
+  public void load_rule_with_defaults_from_annotation_without_resource_folder() {
+    @Rule(key = "MyDefaultCheck", name = "My default check", description = "Description of my default check")
+    class TestRule {
+    }
+
+    ruleMetadataLoader = new RuleMetadataLoader(SONAR_RUNTIME_9_3);
+    ruleMetadataLoader.addRulesByAnnotatedClass(newRepository, singletonList(TestRule.class));
+    newRepository.done();
+
+    RulesDefinition.Repository repository = context.repository(RULE_REPOSITORY_KEY);
+    RulesDefinition.Rule rule = repository.rule("MyDefaultCheck");
+    assertThat(rule).isNotNull();
+    assertThat(rule.severity()).isEqualTo("MAJOR");
+    assertThat(rule.type()).isEqualTo(RuleType.CODE_SMELL);
+    assertThat(rule.status()).isEqualTo(RuleStatus.READY);
+    assertThat(rule.tags()).isEmpty();
+  }
+
+  @Test
+  public void add_rules_by_rule_key_without_resource_folder_throws() {
+    ruleMetadataLoader = new RuleMetadataLoader(SONAR_RUNTIME_9_3);
+    List<String> ruleKeys = singletonList("S100");
+    assertThrows("Resource folder is required to load a rule by its key: S100", IllegalStateException.class,
+      () -> ruleMetadataLoader.addRulesByRuleKey(newRepository, ruleKeys));
   }
 
   @Test


### PR DESCRIPTION
## What

Fixes ACOMMONS-1: `RuleMetadataLoader` ignored every field of the `org.sonar.check.Rule` annotation except `key`.

## Why

`addRuleByAnnotatedClass` always read a JSON and an HTML file to fill in name, description, severity, tags and status, even when the `@Rule` annotation already carried those same values. That file read ran every time afterward and overwrote whatever the annotation had set. So a custom rule that relied only on the annotation, like the one in the ticket, just didn't work. Every rule needed a JSON+HTML pair no matter how much metadata was already sitting in the annotation.

## Fix

- When `RuleMetadataLoader` is built with the constructor that only takes a `SonarRuntime` (no resource folder), `addRulesByAnnotatedClass` skips JSON/HTML loading and keeps whatever `RulesDefinitionAnnotationLoader` already set from the annotation: name, description, priority/severity, tags, status.
- `addRulesByRuleKey` now throws a clear `IllegalStateException` when no resource folder is configured, since there's no annotation to fall back on in that path.
- Behavior with a resource folder is unchanged, existing consumers aren't affected.

Rule type isn't part of the `@Rule` annotation, but the SonarQube API already infers it from tags ("bug" becomes BUG, "security" becomes VULNERABILITY) or falls back to CODE_SMELL. That's enough to cover the ticket's example without adding anything on our side.

## Testing

- Test mirroring the ticket's example: name/description/priority/tags coming only from the annotation.
- Test for the default fallbacks (MAJOR severity, READY status, CODE_SMELL type) when the annotation doesn't set them.
- Test for the new error when `addRulesByRuleKey` is called without a resource folder.
- Updated the module README to mention the annotation-only mode.