### PR TITLE
ACOMMONS-4 Preserve whitespace inside character classes in free-spacing mode

### DIFF
--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/RegexParser.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/RegexParser.java
@@ -933,11 +933,11 @@ public class RegexParser {
   }
 
   protected CharacterClassTree parseCharacterClass() {
-    SourceCharacter openingBracket = characters.getCurrent();
-    characters.moveNext();
     // Whitespace and comments are not stripped inside character classes, even in free-spacing mode.
     boolean previousFreeSpacingMode = characters.getFreeSpacingMode();
     characters.setFreeSpacingMode(false);
+    SourceCharacter openingBracket = characters.getCurrent();
+    characters.moveNext();
     boolean negated = false;
     if (characters.currentIs('^')) {
       characters.moveNext();

--- a/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/RegexParser.java
+++ b/regex-parsing/src/main/java/org/sonarsource/analyzer/commons/regex/RegexParser.java
@@ -935,6 +935,9 @@ public class RegexParser {
   protected CharacterClassTree parseCharacterClass() {
     SourceCharacter openingBracket = characters.getCurrent();
     characters.moveNext();
+    // Whitespace and comments are not stripped inside character classes, even in free-spacing mode.
+    boolean previousFreeSpacingMode = characters.getFreeSpacingMode();
+    characters.setFreeSpacingMode(false);
     boolean negated = false;
     if (characters.currentIs('^')) {
       characters.moveNext();
@@ -946,6 +949,7 @@ public class RegexParser {
     } else {
       expected("']'");
     }
+    characters.setFreeSpacingMode(previousFreeSpacingMode);
     IndexRange range = openingBracket.getRange().extendTo(characters.getCurrentStartIndex());
     return new CharacterClassTree(source, range, openingBracket, negated, contents, activeFlags);
   }

--- a/regex-parsing/src/test/java/org/sonarsource/analyzer/commons/regex/ast/CharacterClassTreeTest.java
+++ b/regex-parsing/src/test/java/org/sonarsource/analyzer/commons/regex/ast/CharacterClassTreeTest.java
@@ -127,6 +127,27 @@ class CharacterClassTreeTest {
   }
 
   @Test
+  void leadingWhitespaceIsPreservedInFreeSpacingMode() {
+    RegexTree regex = assertSuccessfulParse("[ a]", Pattern.COMMENTS);
+    CharacterClassUnionTree union = assertType(CharacterClassUnionTree.class, assertCharacterClass(false, regex));
+    assertListElements(union.getCharacterClasses(),
+      first -> assertCharacter(' ', first),
+      second -> assertCharacter('a', second)
+    );
+  }
+
+  @Test
+  void leadingWhitespaceBeforeCaretPreventsNegationInFreeSpacingMode() {
+    RegexTree regex = assertSuccessfulParse("[ ^a]", Pattern.COMMENTS);
+    CharacterClassUnionTree union = assertType(CharacterClassUnionTree.class, assertCharacterClass(false, regex));
+    assertListElements(union.getCharacterClasses(),
+      first -> assertCharacter(' ', first),
+      second -> assertCharacter('^', second),
+      third -> assertCharacter('a', third)
+    );
+  }
+
+  @Test
   void negatedCharacterClass() {
     RegexTree regex = assertSuccessfulParse("[^a-z]");
     assertCharacterRange('a', 'z', assertCharacterClass(true, regex));

--- a/regex-parsing/src/test/java/org/sonarsource/analyzer/commons/regex/ast/CharacterClassTreeTest.java
+++ b/regex-parsing/src/test/java/org/sonarsource/analyzer/commons/regex/ast/CharacterClassTreeTest.java
@@ -96,6 +96,37 @@ class CharacterClassTreeTest {
   }
 
   @Test
+  void whitespaceIsPreservedInFreeSpacingMode() {
+    RegexTree regex = assertSuccessfulParse("[a b]", Pattern.COMMENTS);
+    CharacterClassUnionTree union = assertType(CharacterClassUnionTree.class, assertCharacterClass(false, regex));
+    assertListElements(union.getCharacterClasses(),
+      first -> assertCharacter('a', first),
+      second -> assertCharacter(' ', second),
+      third -> assertCharacter('b', third)
+    );
+  }
+
+  @Test
+  void commentsAreNotSkippedInFreeSpacingMode() {
+    RegexTree regex = assertSuccessfulParse("[a#b]", Pattern.COMMENTS);
+    CharacterClassUnionTree union = assertType(CharacterClassUnionTree.class, assertCharacterClass(false, regex));
+    assertListElements(union.getCharacterClasses(),
+      first -> assertCharacter('a', first),
+      second -> assertCharacter('#', second),
+      third -> assertCharacter('b', third)
+    );
+  }
+
+  @Test
+  void freeSpacingModeResumesAfterCharacterClass() {
+    RegexTree regex = assertSuccessfulParse("[ab] c", Pattern.COMMENTS);
+    SequenceTree sequence = assertType(SequenceTree.class, regex);
+    assertListSize(2, sequence.getItems());
+    assertCharacterClass(false, sequence.getItems().get(0));
+    assertCharacter('c', sequence.getItems().get(1));
+  }
+
+  @Test
   void negatedCharacterClass() {
     RegexTree regex = assertSuccessfulParse("[^a-z]");
     assertCharacterRange('a', 'z', assertCharacterClass(true, regex));

--- a/regex-parsing/src/test/resources/finders/SingleCharCharacterClassFinder.yml
+++ b/regex-parsing/src/test/resources/finders/SingleCharCharacterClassFinder.yml
@@ -17,6 +17,7 @@
 - '[^abc]'
 - '[^a]'
 - '[a ]': 'x' # Compliant, the space is a literal character, not a stripped whitespace
+- '[ a]': 'x' # Compliant, the leading space is a literal character, not a stripped whitespace
 - '[a]': 'x' # Noncompliant  {{Replace this character class by the character itself.}}
 - 'features': ALL | ^NESTED_CHARTER_CLASS
 - '[[a]]' # Compliant in this mode

--- a/regex-parsing/src/test/resources/finders/SingleCharCharacterClassFinder.yml
+++ b/regex-parsing/src/test/resources/finders/SingleCharCharacterClassFinder.yml
@@ -16,6 +16,8 @@
 - '[0-1]'
 - '[^abc]'
 - '[^a]'
+- '[a ]': 'x' # Compliant, the space is a literal character, not a stripped whitespace
+- '[a]': 'x' # Noncompliant  {{Replace this character class by the character itself.}}
 - 'features': ALL | ^NESTED_CHARTER_CLASS
 - '[[a]]' # Compliant in this mode
 - '[1-2[3]4-5]'


### PR DESCRIPTION
## Summary

Fixes ACOMMONS-4. Enabling the comment/extended regex flag (`x` / `Pattern.COMMENTS`) made `RegexLexer` strip whitespace and `#` comments from inside character classes (`[...]`), not just outside them.

Under PCRE-style `/x` semantics, which this library uses to model PHP, Python, and Ruby regexes, whitespace inside a character class is a literal character, not something to ignore. The lexer removed it anyway, so `[a ]` and `[a]` produced the same AST. That made `SingleCharCharacterClassFinder` flag `[a ]` as redundant, when collapsing it to `a` would actually drop a space that was part of the pattern.

I checked this against real PCRE and Python's `re.VERBOSE`. Both preserve whitespace in character classes under the extended flag, so this was a genuine bug in the lexer, not just a blind spot in this one finder. Fixed it in `RegexParser.parseCharacterClass()`, which now turns off free-spacing mode while parsing between `[` and `]` and turns it back on afterward. Same save/restore pattern already used for inline `(?x:...)` flag groups.

**Update:** an AI-assisted review caught a follow-up bug in the first version of this fix: free-spacing mode was disabled *after* the opening `[` had already been consumed, so the lexer's lookahead skipped whitespace immediately after `[` before the mode-suspend took effect. `[ a]` still collapsed to `[a]`, and `[ ^a]` was wrongly treated as negated. Fixed by disabling free-spacing mode before `[` is read instead of after, so the buffer reset rewinds far enough to preserve that leading whitespace.

## Changes

- `RegexParser.parseCharacterClass()`: suspend free-spacing mode before reading the opening `[`, restore it after the closing `]`.
- `CharacterClassTreeTest`: regression tests for whitespace preservation, `#` no longer being read as a comment inside a class, free-spacing mode resuming correctly afterward, and leading whitespace (including whitespace before `^` no longer being mistaken for negation).
- `SingleCharCharacterClassFinder.yml`: fixture cases reproducing the ticket's false positive (`[a ]` and `[ a]` under `x` are compliant, `[a]` under `x` is still flagged).

## Test plan

- [x] New unit tests in `CharacterClassTreeTest` for whitespace/comment handling under `Pattern.COMMENTS`, including leading whitespace and whitespace before `^`
- [x] New fixture cases in `SingleCharCharacterClassFinder.yml`
- [x] Reverted the parser change locally to confirm the new tests fail without it, then confirmed they pass with it
- [x] Full `regex-parsing` module test suite passes, no regressions
