### PR TITLE
ACOMMONS-67 Bump version of dependencies

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
-      <version>23.0.0</version>
+      <version>26.1.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/performance-measure/pom.xml
+++ b/performance-measure/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.9</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,13 @@
 
   <properties>
     <!-- versions -->
-    <version.sonar.plugin.api>13.5.0.4319</version.sonar.plugin.api>
+    <version.sonar.plugin.api>13.8.0.4399</version.sonar.plugin.api>
     <sonarqube.api.impl.version>10.7.0.96327</sonarqube.api.impl.version>
     <version.assertj>3.27.7</version.assertj>
     <version.jsr305>3.0.2</version.jsr305>
     <version.mockito>5.23.0</version.mockito>
     <version.junit>4.13.2</version.junit>
-    <version.junit-jupiter>5.14.3</version.junit-jupiter>
+    <version.junit-jupiter>5.14.4</version.junit-jupiter>
     <!-- used for deployment to SonarSource Artifactory -->
     <gitRepositoryName>sonar-analyzer-commons</gitRepositoryName>
     <artifactsToPublish>${project.groupId}:sonar-analyzer-commons:jar,${project.groupId}:sonar-analyzer-test-commons:jar,${project.groupId}:sonar-analyzer-recognizers:jar,${project.groupId}:sonar-xml-parsing:jar,${project.groupId}:test-sonar-xml-parsing:jar,${project.groupId}:sonar-regex-parsing:jar</artifactsToPublish>

--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,9 @@
     <sonarqube.api.impl.version>10.7.0.96327</sonarqube.api.impl.version>
     <version.assertj>3.27.7</version.assertj>
     <version.jsr305>3.0.2</version.jsr305>
-    <version.mockito>3.5.7</version.mockito>
+    <version.mockito>5.23.0</version.mockito>
     <version.junit>4.13.2</version.junit>
-    <version.junit-jupiter>5.8.1</version.junit-jupiter>
+    <version.junit-jupiter>5.14.3</version.junit-jupiter>
     <!-- used for deployment to SonarSource Artifactory -->
     <gitRepositoryName>sonar-analyzer-commons</gitRepositoryName>
     <artifactsToPublish>${project.groupId}:sonar-analyzer-commons:jar,${project.groupId}:sonar-analyzer-test-commons:jar,${project.groupId}:sonar-analyzer-recognizers:jar,${project.groupId}:sonar-xml-parsing:jar,${project.groupId}:test-sonar-xml-parsing:jar,${project.groupId}:sonar-regex-parsing:jar</artifactsToPublish>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
   <properties>
     <!-- versions -->
-    <version.sonar.plugin.api>13.5.0.4319</version.sonar.plugin.api>
+    <version.sonar.plugin.api>13.9.0.4417</version.sonar.plugin.api>
     <sonarqube.api.impl.version>10.7.0.96327</sonarqube.api.impl.version>
     <version.assertj>3.27.7</version.assertj>
     <version.jsr305>3.0.2</version.jsr305>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
   <properties>
     <!-- versions -->
-    <version.sonar.plugin.api>13.9.0.4417</version.sonar.plugin.api>
+    <version.sonar.plugin.api>13.5.0.4319</version.sonar.plugin.api>
     <sonarqube.api.impl.version>10.7.0.96327</sonarqube.api.impl.version>
     <version.assertj>3.27.7</version.assertj>
     <version.jsr305>3.0.2</version.jsr305>


### PR DESCRIPTION
- **Dependency updates:**
  - Bumped `Mockito` to `5.23.0`, and `JUnit Jupiter` to `5.14.3` in the root `pom.xml`.
  - Updated `annotations` to `26.1.0` in `commons/pom.xml` and `Gson` to `2.14.0` in `performance-measure/pom.xml`.

<sub>This will update automatically on new commits.</sub>

----
## Summary by Gitar

- **Dependency updates:**
  - Bumped `sonar-plugin-api` to `13.8.0.4399`, `Mockito` to `5.23.0`, and `JUnit Jupiter` to `5.14.4` in the root `pom.xml`.
  - Updated `annotations` to `26.1.0` in `commons/pom.xml` and `Gson` to `2.14.0` in `performance-measure/pom.xml`.

<sub>This will update automatically on new commits.</sub>