### PR TITLE
ACOMMONS-83 Add **/Test/** and **/Tests/** to default test file patterns

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifier.java
@@ -54,7 +54,7 @@ public final class TestFileClassifier {
 
   // Fallback when no patterns are registered: test directories only, to minimize false positives.
   private static final List<WildcardPattern> DEFAULT_PATTERNS =
-    Stream.of("**/test/**", "**/tests/**", "**/__tests__/**")
+    Stream.of("**/Test/**", "**/Tests/**", "**/test/**", "**/tests/**", "**/__tests__/**")
       .map(WildcardPattern::create)
       .toList();
 

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifierTest.java
@@ -84,6 +84,8 @@ class TestFileClassifierTest {
   @Test
   void shouldFallBackToGenericTestDirectoriesWhenNoPatternsRegistered() {
     var classifier = TestFileClassifier.of(config()); // no globs registered
+    assertThat(classifier.looksLikeTestFile(file("src/Test/java/Foo.java"))).isTrue();
+    assertThat(classifier.looksLikeTestFile(file("a/Tests/Foo.java"))).isTrue();
     assertThat(classifier.looksLikeTestFile(file("src/test/java/Foo.java"))).isTrue();
     assertThat(classifier.looksLikeTestFile(file("a/tests/Foo.java"))).isTrue();
     assertThat(classifier.looksLikeTestFile(file("a/__tests__/Foo.js"))).isTrue();


### PR DESCRIPTION
Fixes https://sonarsource.atlassian.net/browse/ACOMMONS-83

The default test file patterns lacked capitalised `Test` and `Tests` directory variants. Since `WildcardPattern` matching is case-sensitive, files under folders named `Test/` or `Tests/` were not detected as test files, causing false positives.

## Changes
- Added `**/Test/**` and `**/Tests/**` to `DEFAULT_PATTERNS` in `TestFileClassifier`
- Extended `shouldFallBackToGenericTestDirectoriesWhenNoPatternsRegistered` with assertions for the new patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)