### PR TITLE
ACOMMONS-84 Honor sonar.secrets.disableTestFileDetection in TestFileClassifier

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifier.java
@@ -41,6 +41,9 @@ public final class TestFileClassifier {
   /** Generic opt-out: disables the test-file heuristic for every analyzer that uses this classifier. */
   public static final String HEURISTIC_DISABLED_KEY = "sonar.testFileHeuristic.disabled";
 
+  /** sonar-text's equivalent opt-out; also disables the test-file heuristic. */
+  public static final String HEURISTIC_DISABLED_KEY_SONARTEXT = "sonar.secrets.disableTestFileDetection";
+
   private static final Logger LOG = LoggerFactory.getLogger(TestFileClassifier.class);
 
   private static final String HEURISTIC_APPLIED_WARNING =
@@ -108,7 +111,8 @@ public final class TestFileClassifier {
 
   private static boolean isTestSourceConfigured(Configuration config) {
     return isSet(config, "sonar.tests")
-      || config.getBoolean(HEURISTIC_DISABLED_KEY).orElse(false);
+      || config.getBoolean(HEURISTIC_DISABLED_KEY).orElse(false)
+      || config.getBoolean(HEURISTIC_DISABLED_KEY_SONARTEXT).orElse(false);
   }
 
   private static boolean isSet(Configuration config, String key) {

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifierTest.java
@@ -127,6 +127,12 @@ class TestFileClassifierTest {
   }
 
   @Test
+  void shouldDisableHeuristicOnSecretsOptOutProperty() {
+    var classifier = classifier(config(TestFileClassifier.HEURISTIC_DISABLED_KEY_SONARTEXT, "true"));
+    assertThat(classifier.looksLikeTestFile(file("a/FooTest.java"))).isFalse();
+  }
+
+  @Test
   void contextOverloadShouldMatchConvenienceOverload() {
     var classifier = classifier(config());
     var testFile = file("a/FooTest.java");


### PR DESCRIPTION
Makes the shared `TestFileClassifier` in analyzer-commons honor the sonar-text secrets analyzer property `sonar.secrets.disableTestFileDetection`, in addition to the existing generic `sonar.testFileHeuristic.disabled` opt-out. Either key now disables the path-based test-file heuristic, so every analyzer that uses `TestFileClassifier` (go, iac, xml, tsql, slang, …) gets the behavior — the gating stays in commons rather than being reimplemented per analyzer.

Adds the public constant `HEURISTIC_DISABLED_KEY_SONARTEXT`, OR's it into `isTestSourceConfigured(...)` alongside the existing key, and adds a test mirroring the existing opt-out test.

Note that `sonar.secrets.*` is a secrets-scoped namespace but `TestFileClassifier` is shared beyond secrets analysis; this intentionally lets the property disable the heuristic for all consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)