### PR TITLE
ACOMMONS-86 Improve regexes exposed from SecretClassifier to be JavaScript friendly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,12 +241,8 @@ jobs:
       contents: write
     steps:
       - *checkout
-      # Promote the separate `_npm` build-info with the standard action, same as the Maven `promote` job.
-      # promote-pull-request is false because npm has no -dev feed: PR builds stay in -qa, while master/
-      # branch-* builds move the .tgz to -builds (target derived from the build-info's ARTIFACTORY_DEPLOY_REPO,
-      # …-qa -> …-builds), which the virtual `npm` repo aggregates for SonarJS to consume.
       - name: Promote npm build
         uses: SonarSource/ci-github-actions/promote@v1
         with:
           build-name: ${{ github.event.repository.name }}_npm
-          promote-pull-request: false
+          promote-pull-request: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,8 +91,8 @@ jobs:
           tool_versions: |
             jfrog-cli 2.103
 
-      - name: Get NuGet deployer token
-        id: nuget-secrets
+      - name: Get QA deployer token
+        id: deployer-secrets
         if: steps.build-maven.outputs.deployed == 'true'
         uses: SonarSource/vault-action-wrapper@v3
         with:
@@ -103,7 +103,7 @@ jobs:
         if: steps.build-maven.outputs.deployed == 'true'
         shell: bash
         env:
-          ARTIFACTORY_ACCESS_TOKEN: ${{ steps.nuget-secrets.outputs.vault && fromJSON(steps.nuget-secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN || '' }}
+          ARTIFACTORY_ACCESS_TOKEN: ${{ steps.deployer-secrets.outputs.vault && fromJSON(steps.deployer-secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN || '' }}
           BUILD_NUMBER: ${{ steps.build-maven.outputs.BUILD_NUMBER }}
           NUPKG_DIR: ${{ steps.nupkg.outputs.dir }}
           NUPKG_ID: ${{ steps.nupkg.outputs.id }}
@@ -121,6 +121,44 @@ jobs:
           jf rt upload --flat \
             --build-name="$BUILD_NAME" --build-number="$BUILD_NUMBER" --module="$MODULE_GAV" \
             "${NUPKG_DIR}/*.nupkg" "sonarsource-nuget-qa/"
+          jf rt build-collect-env "$BUILD_NAME" "$BUILD_NUMBER"
+          jf rt build-publish "$BUILD_NAME" "$BUILD_NUMBER"
+
+      - name: Deploy npm package to Repox
+        if: steps.build-maven.outputs.deployed == 'true'
+        shell: bash
+        env:
+          BUILD_NUMBER: ${{ steps.build-maven.outputs.BUILD_NUMBER }}
+          PROJECT_VERSION: ${{ steps.build-maven.outputs.project-version }}
+        run: |
+          set -euo pipefail
+          MODULE=sonar-analyzer-commons-configurations
+          DEPLOY_REPO=sonarsource-npm-public-qa
+          PKG_NAME=analyzer-commons-configurations
+          # The assembly names the tarball with the 4-part Maven version, e.g. 2.28.0.1234.
+          SRC="${MODULE}/target/${MODULE}-${PROJECT_VERSION}-npm.tar.gz"
+          # npm needs semver: rewrite the trailing .BUILD to a -BUILD prerelease (2.28.0.1234 -> 2.28.0-1234).
+          # Must match the version baked into the tarball's package.json (${npm.package.version} in the module).
+          NPM_VERSION="$(printf '%s' "$PROJECT_VERSION" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+)\.([0-9]+)$/\1-\2/')"
+          if [[ ! -f "$SRC" ]]; then
+            echo "::error::Expected npm package not found at $SRC"
+            ls -la "${MODULE}/target" || true
+            exit 1
+          fi
+          # Separate build-info name so it does not collide with the Maven (github.repository) or _nuget build-info.
+          BUILD_NAME="${GITHUB_REPOSITORY#*/}_npm"
+          MODULE_GAV="org.sonarsource.analyzer-commons:@sonarsource/${PKG_NAME}:${NPM_VERSION}"
+          # Canonical scoped-npm layout path so Artifactory indexes it and the metadata's tarball URL is correct.
+          TARGET="${DEPLOY_REPO}/@sonarsource/${PKG_NAME}/-/${PKG_NAME}-${NPM_VERSION}.tgz"
+          jf config use repox
+          jf rt upload --flat \
+            --build-name="$BUILD_NAME" --build-number="$BUILD_NUMBER" --module="$MODULE_GAV" \
+            "$SRC" "$TARGET"
+          # The promote-npm job (ci-github-actions/promote@v1) reads these from the build-info to derive the
+          # target repo (…-qa -> …-builds) and the promoted version, so export them before build-collect-env
+          # captures the environment into buildInfo.env.
+          export ARTIFACTORY_DEPLOY_REPO="$DEPLOY_REPO"
+          export PROJECT_VERSION="$NPM_VERSION"
           jf rt build-collect-env "$BUILD_NAME" "$BUILD_NUMBER"
           jf rt build-publish "$BUILD_NAME" "$BUILD_NUMBER"
 
@@ -192,3 +230,23 @@ jobs:
             exit 1
           fi
           echo "Verified ${FOUND} NuGet package(s) from ${BUILD_NAME}/${BUILD_NUMBER} in ${TARGET_REPO}"
+
+  promote-npm:
+    needs: [ build ]
+    if: needs.build.outputs.deployed == 'true'
+    runs-on: sonar-xs
+    name: Promote npm
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - *checkout
+      # Promote the separate `_npm` build-info with the standard action, same as the Maven `promote` job.
+      # promote-pull-request is false because npm has no -dev feed: PR builds stay in -qa, while master/
+      # branch-* builds move the .tgz to -builds (target derived from the build-info's ARTIFACTORY_DEPLOY_REPO,
+      # …-qa -> …-builds), which the virtual `npm` repo aggregates for SonarJS to consume.
+      - name: Promote npm build
+        uses: SonarSource/ci-github-actions/promote@v1
+        with:
+          build-name: ${{ github.event.repository.name }}_npm
+          promote-pull-request: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,3 +77,45 @@ jobs:
             --source-repo="sonarsource-nuget-public" \
             --copy=true
 
+  # Promote the npm package from the public build feed to the release feed. As with NuGet, the Maven
+  # release above does not handle it (the .tgz is published to the npm feed, not as a Maven artifact).
+  promote-npm:
+    needs: [release]
+    runs-on: sonar-xs-public
+    name: Promote npm to releases
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Install jfrog-cli
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
+        with:
+          cache: true
+          tool_versions: |
+            jfrog-cli 2.103
+      - name: Get promoter token
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-promoter access_token | PROMOTER_ACCESS_TOKEN;
+      - name: Promote npm package to releases
+        shell: bash
+        env:
+          PROMOTER_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).PROMOTER_ACCESS_TOKEN }}
+          # The release tag is the full 4-part version, e.g. 2.27.0.5000; the build number is its last segment.
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          BUILD_NAME="${GITHUB_REPOSITORY#*/}_npm"
+          BUILD_NUMBER="${RELEASE_VERSION##*.}"
+          jf config add repox \
+            --artifactory-url="https://repox.jfrog.io/artifactory" \
+            --access-token="$PROMOTER_ACCESS_TOKEN" \
+            --interactive=false
+          jf config use repox
+          jf rt build-promote "$BUILD_NAME" "$BUILD_NUMBER" "sonarsource-npm-public-releases" \
+            --status="Released" \
+            --source-repo="sonarsource-npm-public-builds" \
+            --copy=true
+

--- a/sonar-analyzer-commons-configurations/pom.xml
+++ b/sonar-analyzer-commons-configurations/pom.xml
@@ -153,6 +153,23 @@
               <failIfNoMatch>false</failIfNoMatch>
             </configuration>
           </execution>
+          <!-- npm requires a semver version, but CI stamps a 4-part Maven version (X.Y.Z.BUILD_NUMBER). Rewrite the
+               trailing build segment to a semver prerelease (X.Y.Z.BUILD -> X.Y.Z-BUILD) for the npm package.json.
+               Local -SNAPSHOT and plain 3-part versions do not match and pass through unchanged (both valid semver). -->
+          <execution>
+            <id>derive-npm-package-version</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>npm.package.version</name>
+              <value>${project.version}</value>
+              <regex>^(\d+\.\d+\.\d+)\.(\d+)$</regex>
+              <replacement>$1-$2</replacement>
+              <failIfNoMatch>false</failIfNoMatch>
+            </configuration>
+          </execution>
           <execution>
             <id>attach-configuration-artifacts</id>
             <phase>package</phase>

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslator.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslator.java
@@ -279,6 +279,24 @@ public class RegexTranslator {
    * one: an unbounded quantifier applied to a group whose body itself begins with an unbounded quantifier, e.g.
    * {@code (?:X+)++} or {@code (a+)*+}. Once the possessive marker is dropped these become the classic nested
    * unbounded shape {@code (?:X+)+}, which a JavaScript/RE2 consumer has no atomic groups to guard against.
+   *
+   * <p>The test is deliberately conservative: it only inspects whether the group body <em>starts</em> with an
+   * unbounded quantifier (see {@link #groupBodyStartsWithUnboundedQuantifier}). That is the shape every current
+   * {@link SecretClassifier} pattern relies on to keep an unbounded class safe — a required delimiter at the front,
+   * as in {@code (?:/[^/]++){3,}+}, is not flagged because the leading {@code /} is a bounded literal. Two
+   * imprecisions follow from that narrow test, both acceptable for a build-time guard that must never let a
+   * ReDoS-prone regex through:
+   * <ul>
+   *   <li><b>It may over-reject.</b> A pattern that anchors its unbounded class with a <em>trailing</em> delimiter,
+   *       e.g. {@code (?:[^/]++/){2,}+}, is in fact safe (every iteration must consume the {@code /}) yet is still
+   *       rejected. Proving such a pattern safe means proving the leading class <em>excludes</em> the trailing
+   *       delimiter, and the look-alike {@code (?:.++/){2,}+} is the genuinely dangerous {@code (.&#42;/)+}. Rather than
+   *       build that class-exclusion analysis we err toward rejection. No shipped pattern hits this; a future one
+   *       that does fails the export loudly and can be revisited here.</li>
+   *   <li><b>It may under-detect.</b> Ambiguity that is not visible in the first atom, such as an unbounded
+   *       alternation branch {@code (?:a|b+)+}, is not caught. Adding such a pattern to {@link SecretClassifier}
+   *       would require extending this guard.</li>
+   * </ul>
    */
   private static void rejectNestedUnboundedQuantifier(String atom, String base, String regex) {
     if (isUnbounded(base) && !atom.isEmpty() && atom.charAt(0) == '(' && groupBodyStartsWithUnboundedQuantifier(atom)) {
@@ -294,10 +312,15 @@ public class RegexTranslator {
     return "*".equals(base) || "+".equals(base) || base.matches("\\{\\d+,}");
   }
 
-  /** Whether the first atom in the body of {@code group} (a string starting with {@code (}) carries an unbounded quantifier. */
+  /**
+   * Whether the body of {@code group} (a string starting with {@code (}) <em>starts</em> with an atom carrying an
+   * unbounded quantifier. This is the deliberately narrow, first-atom-only test described on
+   * {@link #rejectNestedUnboundedQuantifier}; it is not a general ambiguity analysis.
+   */
   private static boolean groupBodyStartsWithUnboundedQuantifier(String group) {
     int start = groupBodyStart(group, 0);
-    int close = group.length() - 1; // the group's own closing ')'
+    // the group's own closing ')'
+    int close = group.length() - 1;
     if (start >= close) {
       return false;
     }

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslator.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslator.java
@@ -25,13 +25,20 @@ public class RegexTranslator {
   }
 
   /**
-   * Rewrites possessive quantifiers to atomic groups so the regex is valid .NET while keeping
-   * the exact same matching semantics: {@code X*+ -> (?>X*)}, {@code X++ -> (?>X+)}, {@code X?+ -> (?>X?)},
-   * {@code X{n,m}+ -> (?>X{n,m})}. Named groups {@code (?<name>…)} and backrefs {@code \k<name>} are .NET-compatible
-   * and pass through unchanged. Greedy/lazy quantifiers are preserved.
+   * Rewrites the JVM classifier's possessive quantifiers to plain greedy quantifiers so a single regex is valid in
+   * every engine the export targets — .NET, JavaScript and Swift: {@code X*+ -> X*}, {@code X++ -> X+},
+   * {@code X?+ -> X?}, {@code X{n,m}+ -> X{n,m}}. .NET and Swift also accept atomic groups {@code (?>X+)} and the
+   * possessive quantifiers themselves, but JavaScript supports neither, so the portable form drops atomicity entirely.
    *
-   * @throws IllegalArgumentException if the regex uses a Java-only construct this translator cannot faithfully
-   *   render for .NET (see {@link #rejectUnsupportedConstructs(String)}).
+   * <p>Dropping atomicity is match-preserving for the current {@link SecretClassifier} patterns because every
+   * possessive quantifier there is followed either by a delimiter the preceding negated class excludes (e.g. the
+   * {@code \}} after {@code [^}]++}) or by the {@code $} anchor; in both cases greedy backtracking has nothing to
+   * give back and produces the identical match. Named groups {@code (?<name>…)} and backrefs {@code \k<name>} are
+   * portable and pass through unchanged. Greedy and lazy quantifiers are preserved.
+   *
+   * @throws IllegalArgumentException if the regex uses a construct this translator cannot faithfully render for all
+   *   target engines: a Java-only construct (see {@link #rejectUnsupportedConstructs(String)}), or a possessive
+   *   quantifier whose greedy rewrite would be ReDoS-prone (see {@link #rejectNestedUnboundedQuantifier}).
    */
   static String toPortableRegex(String regex) {
     rejectUnsupportedConstructs(regex);
@@ -67,13 +74,10 @@ public class RegexTranslator {
         out.append(atom);
       } else {
         i = q.next;
-        if (q.possessive) {
-          out.append("(?>").append(atom).append(q.base).append(')');
-        } else {
-          out.append(atom).append(q.base);
-          if (q.lazy) {
-            out.append('?');
-          }
+        rejectNestedUnboundedQuantifier(atom, q.base, regex);
+        out.append(atom).append(q.base);
+        if (q.lazy) {
+          out.append('?');
         }
       }
     }
@@ -158,24 +162,27 @@ public class RegexTranslator {
 
   /** Reconstructs the group at {@code i} with its body translated, so nested possessive quantifiers are rewritten. */
   private static String translateGroup(String re, int i) {
-    int bodyStart;
-    if (re.startsWith("(?", i)) {
-      if (re.startsWith("(?<=", i) || re.startsWith("(?<!", i)) {
-        bodyStart = i + 4;
-      } else if (re.startsWith("(?<", i)) {
-        // Named group (?<name>… ; body starts after the closing '>'.
-        bodyStart = re.indexOf('>', i + 2) + 1;
-      } else {
-        // (?:  (?=  (?!  (?>
-        bodyStart = i + 3;
-      }
-    } else {
-      bodyStart = i + 1;
-    }
+    int bodyStart = groupBodyStart(re, i);
     int close = matchingParen(re, i);
     String prefix = re.substring(i, bodyStart);
     String body = re.substring(bodyStart, close);
     return prefix + toPortableRegex(body) + ")";
+  }
+
+  /** Returns the index where the body of the group opening at {@code i} begins, skipping any {@code (?…)} prefix. */
+  private static int groupBodyStart(String re, int i) {
+    if (re.startsWith("(?", i)) {
+      if (re.startsWith("(?<=", i) || re.startsWith("(?<!", i)) {
+        return i + 4;
+      }
+      if (re.startsWith("(?<", i)) {
+        // Named group (?<name>… ; body starts after the closing '>'.
+        return re.indexOf('>', i + 2) + 1;
+      }
+      // (?:  (?=  (?!  (?>
+      return i + 3;
+    }
+    return i + 1;
   }
   /** Returns the index of the {@code )} matching the {@code (} at {@code open}, accounting for classes and escapes. */
   private static int matchingParen(String re, int open) {
@@ -266,7 +273,54 @@ public class RegexTranslator {
     }
     return new RegexTranslator.Quantifier(base, possessive, lazy, after);
   }
-  
+
+  /**
+   * Rejects the one possessive&rarr;greedy rewrite that could turn a safe pattern into a catastrophic-backtracking
+   * one: an unbounded quantifier applied to a group whose body itself begins with an unbounded quantifier, e.g.
+   * {@code (?:X+)++} or {@code (a+)*+}. Once the possessive marker is dropped these become the classic nested
+   * unbounded shape {@code (?:X+)+}, which a JavaScript/RE2 consumer has no atomic groups to guard against.
+   */
+  private static void rejectNestedUnboundedQuantifier(String atom, String base, String regex) {
+    if (isUnbounded(base) && !atom.isEmpty() && atom.charAt(0) == '(' && groupBodyStartsWithUnboundedQuantifier(atom)) {
+      throw new IllegalArgumentException(
+        "Cannot export a portable regex: dropping the possessive quantifier would leave a ReDoS-prone nested " +
+          "unbounded quantifier (e.g. \"(?:X+)+\"), which JavaScript/RE2 cannot guard with atomic groups, in pattern: " +
+          regex);
+    }
+  }
+
+  /** Whether {@code base} repeats without an upper bound: {@code *}, {@code +} or {@code {n,}} (but not {@code {n,m}}). */
+  private static boolean isUnbounded(String base) {
+    return "*".equals(base) || "+".equals(base) || base.matches("\\{\\d+,}");
+  }
+
+  /** Whether the first atom in the body of {@code group} (a string starting with {@code (}) carries an unbounded quantifier. */
+  private static boolean groupBodyStartsWithUnboundedQuantifier(String group) {
+    int start = groupBodyStart(group, 0);
+    int close = group.length() - 1; // the group's own closing ')'
+    if (start >= close) {
+      return false;
+    }
+    int afterFirstAtom = endOfAtom(group, start);
+    RegexTranslator.Quantifier q = readQuantifier(group, afterFirstAtom);
+    return q != null && isUnbounded(q.base);
+  }
+
+  /** Returns the index just past the single atom starting at {@code i} (escape, class, group or lone character). */
+  private static int endOfAtom(String re, int i) {
+    char c = re.charAt(i);
+    if (c == '\\') {
+      return readEscape(re, i);
+    }
+    if (c == '[') {
+      return readClassEnd(re, i);
+    }
+    if (c == '(') {
+      return matchingParen(re, i) + 1;
+    }
+    return i + 1;
+  }
+
   private static final class Quantifier {
     private final String base;
     private final boolean possessive;

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporter.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporter.java
@@ -34,9 +34,11 @@ import org.sonarsource.analyzer.commons.appsec.SecretClassifier;
  * Generates the machine-readable JSON export of {@link SecretClassifier}'s secret-exclusion patterns, the single
  * source of truth shared with non-JVM analyzers (SonarJS, sonar-dotnet, …).
  *
- * <p>The JVM classifier keeps its possessive quantifiers for performance; on export they are rewritten to the
- * semantically identical atomic groups ({@code X++} &rarr; {@code (?>X+)}), which .NET supports and possessive
- * quantifiers do not. See {@link RegexTranslator#toPortableRegex(String)}.
+ * <p>The JVM classifier keeps its possessive quantifiers for performance; on export they are rewritten to plain
+ * greedy quantifiers ({@code X++} &rarr; {@code X+}) so a single regex compiles in every consumer — .NET, JavaScript
+ * and Swift. JavaScript supports neither possessive quantifiers nor atomic groups, so atomicity is dropped rather
+ * than preserved as {@code (?>X+)}; this is match-preserving for the current patterns. See
+ * {@link RegexTranslator#toPortableRegex(String)}.
  *
  * <p>Output is deterministic and pretty-printed so the artifact diffs cleanly. Run via {@code exec:java} at build time;
  * {@code main} takes the target file path as its single argument.

--- a/sonar-analyzer-commons-configurations/src/main/packaging/npm/package.json
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonarsource/analyzer-commons-configurations",
-  "version": "${package.version}",
+  "version": "${npm.package.version}",
   "description": "Shared analyzer configuration data (secret-exclusion regexes) generated from the sonar-analyzer-commons SecretClassifier, for use by non-JVM SonarSource analyzers.",
   "license": "LGPL-3.0-only",
   "files": [

--- a/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslatorTest.java
+++ b/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslatorTest.java
@@ -113,6 +113,18 @@ class RegexTranslatorTest {
   }
 
   @Test
+  void shouldConservativelyRejectUnboundedClassWithTrailingDelimiter() {
+    // (?:[^/]++/){2,}+ is in fact safe (each iteration must consume the trailing '/'), but proving that requires
+    // showing the leading class excludes the delimiter, and the look-alike (?:.++/){2,}+ is the genuinely
+    // ReDoS-prone (.*/)+ form. The first-atom guard deliberately errs toward rejection here rather than build that
+    // class-exclusion analysis; see RegexTranslator#rejectNestedUnboundedQuantifier. Pinned so it is not "fixed"
+    // into silently accepting the dangerous look-alike.
+    assertThatThrownBy(() -> RegexTranslator.toPortableRegex("(?:[^/]++/){2,}+"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("ReDoS-prone");
+  }
+
+  @Test
   void exportedPatternsShouldContainNoAtomicGroups() {
     for (String regex : sourceRegexes()) {
       assertThat(RegexTranslator.toPortableRegex(regex))

--- a/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslatorTest.java
+++ b/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslatorTest.java
@@ -51,17 +51,17 @@ class RegexTranslatorTest {
 
   static Stream<Arguments> translationCases() {
     return Stream.of(
-      // possessive quantifiers become atomic groups
-      Arguments.of("a++", "(?>a+)"),
-      Arguments.of("a*+", "(?>a*)"),
-      Arguments.of("a?+", "(?>a?)"),
-      Arguments.of("[^}]++", "(?>[^}]+)"),
-      Arguments.of("\\d{0,5}+", "(?>\\d{0,5})"),
-      Arguments.of("\\k<repeated>*+", "(?>\\k<repeated>*)"),
-      // nested possessive quantifiers, inner and outer both rewritten
-      Arguments.of("(?:/[a-z0-9_.-]++){3,}+", "(?>(?:/(?>[a-z0-9_.-]+)){3,})"),
+      // possessive quantifiers become plain greedy quantifiers (JS/RE2 support neither possessive nor atomic groups)
+      Arguments.of("a++", "a+"),
+      Arguments.of("a*+", "a*"),
+      Arguments.of("a?+", "a?"),
+      Arguments.of("[^}]++", "[^}]+"),
+      Arguments.of("\\d{0,5}+", "\\d{0,5}"),
+      Arguments.of("\\k<repeated>*+", "\\k<repeated>*"),
+      // nested possessive quantifiers, inner and outer both rewritten to greedy
+      Arguments.of("(?:/[a-z0-9_.-]++){3,}+", "(?:/[a-z0-9_.-]+){3,}"),
       // escaped delimiters around a possessive negated class
-      Arguments.of("^%?\\{[^}]++\\}$", "^%?\\{(?>[^}]+)\\}$"),
+      Arguments.of("^%?\\{[^}]++\\}$", "^%?\\{[^}]+\\}$"),
       // greedy / lazy / fixed quantifiers are preserved
       Arguments.of("a+", "a+"),
       Arguments.of("a+?", "a+?"),
@@ -83,8 +83,42 @@ class RegexTranslatorTest {
 
   @ParameterizedTest
   @MethodSource("translationCases")
-  void shouldTranslatePossessiveQuantifiersToAtomicGroups(String input, String expected) {
+  void shouldRewritePossessiveQuantifiersToGreedy(String input, String expected) {
     assertThat(RegexTranslator.toPortableRegex(input)).isEqualTo(expected);
+  }
+
+  static Stream<String> redosProneRewrites() {
+    return Stream.of(
+      // dropping the possessive marker would leave nested unbounded quantifiers with no atomic-group guard
+      "(?:\\w+)++",
+      "(a+)*+",
+      "(?:[a-z]+)*+",
+      "(\\d+){2,}+");
+  }
+
+  @ParameterizedTest
+  @MethodSource("redosProneRewrites")
+  void shouldRejectRewritesThatWouldBecomeReDoSProne(String input) {
+    assertThatThrownBy(() -> RegexTranslator.toPortableRegex(input))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("ReDoS-prone")
+      .hasMessageContaining(input);
+  }
+
+  @Test
+  void shouldAllowNestedQuantifiersSeparatedByARequiredLiteral() {
+    // Each iteration must start with '/', so this is unambiguous and safe to flatten to greedy - the shape
+    // SecretClassifier actually ships. It must not be mistaken for the ReDoS-prone nested form.
+    assertThat(RegexTranslator.toPortableRegex("(?:/[^/]++){3,}+")).isEqualTo("(?:/[^/]+){3,}");
+  }
+
+  @Test
+  void exportedPatternsShouldContainNoAtomicGroups() {
+    for (String regex : sourceRegexes()) {
+      assertThat(RegexTranslator.toPortableRegex(regex))
+        .as("atomic group remains in translated pattern (unsupported by JavaScript): %s", regex)
+        .doesNotContain("(?>");
+    }
   }
 
   static Stream<Arguments> unsupportedConstructs() {

--- a/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporterTest.java
+++ b/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporterTest.java
@@ -93,7 +93,7 @@ class SecretPatternsExporterTest {
         assertThat(RegexTranslator.toPortableRegex(pattern))
           .as("exported pattern is not fully translated: %s", pattern)
           .isEqualTo(pattern);
-        // ...and it is a regex the .NET-portable form still compiles as Java too.
+        // ...and the portable form still compiles as a Java regex too.
         assertThat(SecretPatternsExporter.compilePortable(pattern))
           .as("exported pattern does not compile: %s", pattern)
           .isNotNull();


### PR DESCRIPTION
----
## Summary by Gitar

- **Regex portability:**
  - Updated `RegexTranslator` to map possessive quantifiers to greedy ones for JavaScript/RE2 compatibility, dropping atomicity.
  - Added a strict guard in `RegexTranslator` to reject rewrites that would create potentially ReDoS-prone nested unbounded quantifiers.
- **NPM CI/CD pipeline:**
  - Added automated deployment and promotion workflows for the `analyzer-commons-configurations` npm package to Repox.
  - Updated `pom.xml` to derive a semver-compliant package version from the 4-part Maven build version.
- **Test coverage:**
  - Refactored `RegexTranslatorTest` to verify greedy-quantifier translation and added specific test cases for detecting ReDoS-prone patterns.


<sub>This will update automatically on new commits.</sub>