### PR TITLE
ACOMMONS-87 Fix Next quality gate

### DIFF
--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/package-info.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * SonarSource Analyzers Commons Configurations
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+/**
+ * Exports analyzer configuration derived from the canonical JVM implementation for use by other runtimes.
+ */
+@ParametersAreNonnullByDefault
+package org.sonarsource.analyzer.commons.appsec.export;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
## Summary

- document the new `org.sonarsource.analyzer.commons.appsec.export` package
- apply the repository-wide non-null parameter default
- resolve the `java:S1228` issue failing the master quality gate on Next

## Verification

- `mvn -pl sonar-analyzer-commons-configurations -am verify`
- 911 tests passed across the focused reactor