### PR TITLE
CLP-212: Migrate scanner test fixtures

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -44,8 +44,13 @@
 
     <!-- TEST -->
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>plugin-api-scanner-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>sensor-test-fixtures</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/EducationRuleLoaderTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/EducationRuleLoaderTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.analyzer.commons;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,12 +30,11 @@ import org.slf4j.event.Level;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.server.rule.RuleDescriptionSection;
-import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.Context;
 import org.sonar.api.server.rule.RulesDefinition.NewRepository;
 import org.sonar.api.server.rule.RulesDefinition.Repository;
+import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionAnnotationLoader;
 import org.sonar.api.testfixtures.log.LogTester;
 import org.sonar.api.utils.Version;
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class EducationRuleLoaderTest {
 
-  private static final SonarRuntime RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(9, 8), SonarQubeSide.SERVER, SonarEdition.DEVELOPER);
+  private static final SonarRuntime RUNTIME = TestSonarRuntime.forSonarQube(Version.create(9, 8), SonarQubeSide.SERVER, SonarEdition.DEVELOPER);
   private static final Path EDUCATION_TEST_FILES_DIRECTORY = Paths.get("src/test/resources/org/sonarsource/analyzer/commons/education");
   private static final String RULE_REPOSITORY_KEY = "rule-definition-test";
 
@@ -65,24 +65,24 @@ public class EducationRuleLoaderTest {
 
   @Test
   public void supports_education_rules_descriptions() {
-    assertThat(new EducationRuleLoader(SonarRuntimeImpl.forSonarQube(Version.create(9, 5), SonarQubeSide.SERVER, SonarEdition.DEVELOPER)).isEducationRuleDescriptionSupported()).isTrue();
-    assertThat(new EducationRuleLoader(SonarRuntimeImpl.forSonarQube(Version.create(9, 4), SonarQubeSide.SERVER, SonarEdition.DEVELOPER)).isEducationRuleDescriptionSupported()).isFalse();
-    assertThat(new EducationRuleLoader(SonarRuntimeImpl.forSonarQube(Version.create(9, 6), SonarQubeSide.SERVER, SonarEdition.SONARCLOUD)).isEducationRuleDescriptionSupported()).isTrue();
-    assertThat(new EducationRuleLoader(SonarRuntimeImpl.forSonarLint(Version.create(9, 6))).isEducationRuleDescriptionSupported()).isTrue();
+    assertThat(new EducationRuleLoader(TestSonarRuntime.forSonarQube(Version.create(9, 5), SonarQubeSide.SERVER, SonarEdition.DEVELOPER)).isEducationRuleDescriptionSupported()).isTrue();
+    assertThat(new EducationRuleLoader(TestSonarRuntime.forSonarQube(Version.create(9, 4), SonarQubeSide.SERVER, SonarEdition.DEVELOPER)).isEducationRuleDescriptionSupported()).isFalse();
+    assertThat(new EducationRuleLoader(TestSonarRuntime.forSonarQube(Version.create(9, 6), SonarQubeSide.SERVER, SonarEdition.SONARCLOUD)).isEducationRuleDescriptionSupported()).isTrue();
+    assertThat(new EducationRuleLoader(TestSonarRuntime.forSonarLint(Version.create(9, 6))).isEducationRuleDescriptionSupported()).isTrue();
   }
 
   @Test
   public void supports_education_principles_metadata() {
-    assertThat(new EducationRuleLoader(SonarRuntimeImpl.forSonarQube(Version.create(9, 8), SonarQubeSide.SERVER, SonarEdition.DEVELOPER)).isEducationPrinciplesMetadataSupported()).isTrue();
-    assertThat(new EducationRuleLoader(SonarRuntimeImpl.forSonarQube(Version.create(9, 8), SonarQubeSide.SERVER, SonarEdition.SONARCLOUD)).isEducationPrinciplesMetadataSupported()).isTrue();
-    assertThat(new EducationRuleLoader(SonarRuntimeImpl.forSonarLint(Version.create(9, 8))).isEducationPrinciplesMetadataSupported()).isTrue();
-    assertThat(new EducationRuleLoader(SonarRuntimeImpl.forSonarQube(Version.create(9, 7), SonarQubeSide.SERVER, SonarEdition.DEVELOPER)).isEducationPrinciplesMetadataSupported()).isFalse();
-    assertThat(new EducationRuleLoader(SonarRuntimeImpl.forSonarLint(Version.create(9, 7))).isEducationPrinciplesMetadataSupported()).isFalse();
+    assertThat(new EducationRuleLoader(TestSonarRuntime.forSonarQube(Version.create(9, 8), SonarQubeSide.SERVER, SonarEdition.DEVELOPER)).isEducationPrinciplesMetadataSupported()).isTrue();
+    assertThat(new EducationRuleLoader(TestSonarRuntime.forSonarQube(Version.create(9, 8), SonarQubeSide.SERVER, SonarEdition.SONARCLOUD)).isEducationPrinciplesMetadataSupported()).isTrue();
+    assertThat(new EducationRuleLoader(TestSonarRuntime.forSonarLint(Version.create(9, 8))).isEducationPrinciplesMetadataSupported()).isTrue();
+    assertThat(new EducationRuleLoader(TestSonarRuntime.forSonarQube(Version.create(9, 7), SonarQubeSide.SERVER, SonarEdition.DEVELOPER)).isEducationPrinciplesMetadataSupported()).isFalse();
+    assertThat(new EducationRuleLoader(TestSonarRuntime.forSonarLint(Version.create(9, 7))).isEducationPrinciplesMetadataSupported()).isFalse();
   }
 
   @Test
   public void education_description_content_unsupported_product_runtime() throws IOException {
-    SonarRuntime invalidRuntime = SonarRuntimeImpl.forSonarQube(Version.create(9, 4), SonarQubeSide.SERVER, SonarEdition.DEVELOPER);
+    SonarRuntime invalidRuntime = TestSonarRuntime.forSonarQube(Version.create(9, 4), SonarQubeSide.SERVER, SonarEdition.DEVELOPER);
     EducationRuleLoader educationRuleLoader = new EducationRuleLoader(invalidRuntime);
     String testFileContent = getTestFileContent("valid/S100.html");
     String fallbackDescription = educationRuleLoader.setEducationDescriptionFromHtml(newRule, testFileContent);
@@ -249,7 +249,7 @@ public class EducationRuleLoaderTest {
 
   @Test
   public void education_metadata() {
-    SonarRuntime invalidRuntime = SonarRuntimeImpl.forSonarQube(Version.create(9, 4), SonarQubeSide.SERVER, SonarEdition.DEVELOPER);
+    SonarRuntime invalidRuntime = TestSonarRuntime.forSonarQube(Version.create(9, 4), SonarQubeSide.SERVER, SonarEdition.DEVELOPER);
 
     RulesDefinition.Rule rule = invokeSetEducationMetadataFromJson(invalidRuntime, Map.of("educationPrinciples", List.of("defense_in_depth", "never_trust_user_input")));
     assertThat(rule.educationPrincipleKeys()).isEmpty();

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/ExternalReportProviderTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/ExternalReportProviderTest.java
@@ -16,12 +16,12 @@
  */
 package org.sonarsource.analyzer.commons;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.io.File;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.event.Level;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.testfixtures.log.LogTester;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/ExternalRuleLoaderTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/ExternalRuleLoaderTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.analyzer.commons;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -25,17 +26,14 @@ import org.junit.Test;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.batch.fs.internal.DefaultInputProject;
 import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.batch.sensor.issue.NewExternalIssue;
-import org.sonar.api.batch.sensor.issue.internal.DefaultExternalIssue;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.issue.impact.SoftwareQuality;
 import org.sonar.api.rules.CleanCodeAttribute;
 import org.sonar.api.rules.RuleType;
-import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.Repository;
 import org.sonar.api.server.rule.RulesDefinition.Rule;
+import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.utils.Version;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,8 +56,8 @@ import static org.sonar.api.rules.RuleType.VULNERABILITY;
 
 public class ExternalRuleLoaderTest {
 
-  private static final SonarRuntime RUNTIME_10_0 = SonarRuntimeImpl.forSonarQube(Version.create(10, 0), SonarQubeSide.SERVER, SonarEdition.DEVELOPER);
-  private static final SonarRuntime RUNTIME_10_1 = SonarRuntimeImpl.forSonarQube(Version.create(10, 1), SonarQubeSide.SERVER, SonarEdition.DEVELOPER);
+  private static final SonarRuntime RUNTIME_10_0 = TestSonarRuntime.forSonarQube(Version.create(10, 0), SonarQubeSide.SERVER, SonarEdition.DEVELOPER);
+  private static final SonarRuntime RUNTIME_10_1 = TestSonarRuntime.forSonarQube(Version.create(10, 1), SonarQubeSide.SERVER, SonarEdition.DEVELOPER);
 
   @Test
   public void test_null_runtime() {

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/RuleMetadataLoaderTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/RuleMetadataLoaderTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.analyzer.commons;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -24,19 +25,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.rule.RuleScope;
 import org.sonar.api.rule.RuleStatus;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.debt.DebtRemediationFunction;
 import org.sonar.api.server.rule.RuleParamType;
-import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.NewRepository;
+import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.utils.Version;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
@@ -71,15 +70,15 @@ public class RuleMetadataLoaderTest {
   private NewRepository newRepository;
   private RuleMetadataLoader ruleMetadataLoader;
   // using SonarLint for simplicity (it requires fewer parameters)
-  private static final SonarRuntime SONAR_RUNTIME_9_2 = SonarRuntimeImpl.forSonarLint(Version.create(9, 2));
-  private static final SonarRuntime SONAR_RUNTIME_9_3 = SonarRuntimeImpl.forSonarLint(Version.create(9, 3));
-  private static final SonarRuntime SONAR_RUNTIME_9_5 = SonarRuntimeImpl.forSonarLint(Version.create(9, 5));
-  private static final SonarRuntime SONAR_RUNTIME_9_9 = SonarRuntimeImpl.forSonarLint(Version.create(9, 9));
-  private static final SonarRuntime SONAR_RUNTIME_10_1 = SonarRuntimeImpl.forSonarLint(Version.create(10, 1));
-  private static final SonarRuntime SONAR_RUNTIME_10_10 = SonarRuntimeImpl.forSonarLint(Version.create(10, 10));
-  private static final SonarRuntime SONAR_RUNTIME_10_11 = SonarRuntimeImpl.forSonarLint(Version.create(10, 11));
-  private static final SonarRuntime SONAR_RUNTIME_11_4 = SonarRuntimeImpl.forSonarLint(Version.create(11, 4));
-  private static final SonarRuntime SONAR_RUNTIME_13_3 = SonarRuntimeImpl.forSonarLint(Version.create(13, 3));
+  private static final SonarRuntime SONAR_RUNTIME_9_2 = TestSonarRuntime.forSonarLint(Version.create(9, 2));
+  private static final SonarRuntime SONAR_RUNTIME_9_3 = TestSonarRuntime.forSonarLint(Version.create(9, 3));
+  private static final SonarRuntime SONAR_RUNTIME_9_5 = TestSonarRuntime.forSonarLint(Version.create(9, 5));
+  private static final SonarRuntime SONAR_RUNTIME_9_9 = TestSonarRuntime.forSonarLint(Version.create(9, 9));
+  private static final SonarRuntime SONAR_RUNTIME_10_1 = TestSonarRuntime.forSonarLint(Version.create(10, 1));
+  private static final SonarRuntime SONAR_RUNTIME_10_10 = TestSonarRuntime.forSonarLint(Version.create(10, 10));
+  private static final SonarRuntime SONAR_RUNTIME_10_11 = TestSonarRuntime.forSonarLint(Version.create(10, 11));
+  private static final SonarRuntime SONAR_RUNTIME_11_4 = TestSonarRuntime.forSonarLint(Version.create(11, 4));
+  private static final SonarRuntime SONAR_RUNTIME_13_3 = TestSonarRuntime.forSonarLint(Version.create(13, 3));
 
   @Before
   public void setup() {

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/TestFileClassifierTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.analyzer.commons.appsec;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -23,10 +24,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.config.Configuration;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
   <properties>
     <!-- versions -->
     <version.sonar.plugin.api>13.8.0.4399</version.sonar.plugin.api>
-    <sonarqube.api.impl.version>10.7.0.96327</sonarqube.api.impl.version>
+    <version.sonar.scanner>13.4.1.4007</version.sonar.scanner>
     <version.assertj>3.27.7</version.assertj>
     <version.jsr305>3.0.2</version.jsr305>
     <version.mockito>5.23.0</version.mockito>
@@ -106,9 +106,14 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>org.sonarsource.sonarqube</groupId>
-        <artifactId>sonar-plugin-api-impl</artifactId>
-        <version>${sonarqube.api.impl.version}</version>
+        <groupId>org.sonarsource.scanner.engine</groupId>
+        <artifactId>plugin-api-scanner-impl</artifactId>
+        <version>${version.sonar.scanner}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.sonarsource.scanner.engine</groupId>
+        <artifactId>sensor-test-fixtures</artifactId>
+        <version>${version.sonar.scanner}</version>
       </dependency>
       <dependency>
         <groupId>org.sonarsource.api.plugin</groupId>

--- a/test-xml-parsing/pom.xml
+++ b/test-xml-parsing/pom.xml
@@ -25,8 +25,12 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>plugin-api-scanner-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>sensor-test-fixtures</artifactId>
     </dependency>
 
     <dependency>

--- a/test-xml-parsing/src/main/java/org/sonarsource/analyzer/commons/xml/checks/SonarXmlCheckVerifier.java
+++ b/test-xml-parsing/src/main/java/org/sonarsource/analyzer/commons/xml/checks/SonarXmlCheckVerifier.java
@@ -16,6 +16,8 @@
  */
 package org.sonarsource.analyzer.commons.xml.checks;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -29,14 +31,12 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.TextRange;
-import org.sonar.api.batch.fs.internal.DefaultInputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.batch.sensor.issue.Issue;
 import org.sonar.api.batch.sensor.issue.Issue.Flow;
+import org.sonar.api.batch.sensor.issue.Issue;
 import org.sonar.api.batch.sensor.issue.IssueLocation;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.rule.RuleKey;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultInputFile;
 import org.sonarsource.analyzer.commons.checks.verifier.SingleFileVerifier;
 import org.sonarsource.analyzer.commons.xml.XmlFile;
 import org.sonarsource.analyzer.commons.xml.XmlTextRange;

--- a/test-xml-parsing/src/test/java/org/sonarsource/analyzer/commons/xml/checks/SonarXmlCheckVerifierTest.java
+++ b/test-xml-parsing/src/test/java/org/sonarsource/analyzer/commons/xml/checks/SonarXmlCheckVerifierTest.java
@@ -18,7 +18,7 @@ package org.sonarsource.analyzer.commons.xml.checks;
 
 import org.assertj.core.util.Lists;
 import org.junit.Test;
-import org.sonar.api.config.internal.MapSettings;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 import org.sonarsource.analyzer.commons.xml.XmlFile;
 import org.w3c.dom.Element;
 

--- a/xml-parsing/pom.xml
+++ b/xml-parsing/pom.xml
@@ -56,8 +56,13 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>plugin-api-scanner-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>sensor-test-fixtures</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/xml-parsing/src/test/java/org/sonarsource/analyzer/commons/xml/XmlFileTest.java
+++ b/xml-parsing/src/test/java/org/sonarsource/analyzer/commons/xml/XmlFileTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.analyzer.commons.xml;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -23,7 +24,6 @@ import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.ObjectAssert;
 import org.junit.Test;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonarsource.analyzer.commons.xml.XmlFile.Location;
 import org.w3c.dom.Attr;
 import org.w3c.dom.CDATASection;

--- a/xml-parsing/src/test/java/org/sonarsource/analyzer/commons/xml/XmlParserTest.java
+++ b/xml-parsing/src/test/java/org/sonarsource/analyzer/commons/xml/XmlParserTest.java
@@ -16,13 +16,13 @@
  */
 package org.sonarsource.analyzer.commons.xml;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.junit.Test;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonarsource.analyzer.commons.xml.PrologElement.PrologAttribute;
 import org.sonarsource.analyzer.commons.xml.XmlFile.Location;
 import org.w3c.dom.Attr;

--- a/xml-parsing/src/test/java/org/sonarsource/analyzer/commons/xml/checks/SimpleXPathBasedCheckTest.java
+++ b/xml-parsing/src/test/java/org/sonarsource/analyzer/commons/xml/checks/SimpleXPathBasedCheckTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonarsource.analyzer.commons.xml.checks;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -28,10 +29,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultInputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.testfixtures.log.LogTester;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultInputFile;
 import org.sonarsource.analyzer.commons.xml.XmlFile;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;


### PR DESCRIPTION
## Summary

- replace the SonarQube implementation artifact with scanner-engine 13.4.1 fixtures
- migrate moved scanner implementation imports and use `TestSonarRuntime`
- update the XML test verifier module so consumers can use the new fixture types

## Dependency changes

Before: `commons`, `xml-parsing`, and `test-xml-parsing` depended on `org.sonarsource.sonarqube:sonar-plugin-api-impl`.

After: the modules directly declare `plugin-api-scanner-impl` and `sensor-test-fixtures` at `13.4.1.4007`. `test-xml-parsing` intentionally exposes these at compile scope because its published verifier API constructs and returns scanner fixture types. The resolved Maven graph contains no `sonar-plugin-api-impl`.

`sonar-plugin-api-test-fixtures` remains separate and is retained only where its logging helpers are used.

## Validation

- affected `commons`, `xml-parsing`, and `test-xml-parsing` reactor tests
- Maven dependency-tree check for `org.sonarsource.sonarqube:sonar-plugin-api-impl` (no matches)
- `git diff --check`
