### PR TITLE
ACOMMONS-94 Fix Next quality gate

### DIFF
--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslator.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslator.java
@@ -262,16 +262,14 @@ public class RegexTranslator {
     } else {
       return null;
     }
-    boolean possessive = false;
     boolean lazy = false;
     if (after < n && re.charAt(after) == '+') {
-      possessive = true;
       after++;
     } else if (after < n && re.charAt(after) == '?') {
       lazy = true;
       after++;
     }
-    return new RegexTranslator.Quantifier(base, possessive, lazy, after);
+    return new RegexTranslator.Quantifier(base, lazy, after);
   }
 
   /**
@@ -346,13 +344,11 @@ public class RegexTranslator {
 
   private static final class Quantifier {
     private final String base;
-    private final boolean possessive;
     private final boolean lazy;
     private final int next;
 
-    private Quantifier(String base, boolean possessive, boolean lazy, int next) {
+    private Quantifier(String base, boolean lazy, int next) {
       this.base = base;
-      this.possessive = possessive;
       this.lazy = lazy;
       this.next = next;
     }


### PR DESCRIPTION
## Summary

- remove the obsolete possessive flag from `RegexTranslator.Quantifier`
- continue consuming possessive quantifier markers without retaining unused state
- resolve the `java:S1068` issue failing the master quality gate on Next

## Verification

- `mvn -pl sonar-analyzer-commons-configurations -am -Dtest=RegexTranslatorTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn test`
