### PR TITLE
ACOMMONS-101 Add MuleSoft schema host to cleartext namespace URI authorities

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -117,6 +117,8 @@ public final class CleartextProtocolFilter {
     "^schema\\.org|" +
     // Spring Framework XML schemas
     "^www\\.springframework\\.org|" +
+    // MuleSoft Mule application XML schemas
+    "^www\\.mulesoft\\.org|" +
     // Maven POM / XSD
     "^maven\\.apache\\.org|" +
     // Dublin Core legacy URIs

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -207,6 +207,8 @@ class CleartextProtocolFilterTest {
       "http://docbook.org/ns/docbook",
       "http://graphml.graphdrawing.org/graphml",
       "http://json-schema.org/draft-07/schema",
+      "http://www.mulesoft.org/schema/mule/core",
+      "http://www.mulesoft.org/schema/mule/http",
 
       // Case insensitivity and surrounding whitespace
       "HTTP://LOCALHOST:8080",
@@ -313,6 +315,7 @@ class CleartextProtocolFilterTest {
       "http://metadata.google.internal.evil.com",
       "http://www.w3.org.evil.com/x",
       "http://schema.org.evil.com/Person",
+      "http://www.mulesoft.org.evil.com/schema",
 
       // Userinfo — safe-looking host before @ must not grant safety
       "http://www.w3.org@evil.com",


### PR DESCRIPTION
Adds `www.mulesoft.org` to the `NAMESPACE_URI_AUTHORITIES` allowlist in `CleartextProtocolFilter`.

MuleSoft Mule config files declare XML namespaces like `http://www.mulesoft.org/schema/mule/core`. These are opaque namespace identifiers, not real cleartext connections, so they should not trigger a cleartext-protocol warning.