### PR TITLE
ACOMMONS-102 secretclassifier: filter leetspeak passw0rd variants

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -98,6 +98,8 @@ public final class SecretClassifier {
       "redacted|cafebabe|deadbeef|whatever|123456|admin|pass|secret|default|dummy|qwerty|setting|obfuscated",
       // Password-like words, e.g. "password", "passwd", "pass", "password1234"
       "^(my)?pass(word|wd)?\\d{0,5}+$",
+      // Leetspeak "password" variants the "pass" substring misses, e.g. "p@ssword", "p@ssw0rd"
+      "p[@a]ssw[o0]rd",
       // Boolean / null / scalar literals, e.g. "password = undefined", "enabled: true"
       "^(?:none|undefined|null|true|false|yes|no|1|0)$",
       // Starts with "your", e.g. "yourpassword", "your_super_secret"

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
@@ -45,6 +45,8 @@ class SecretClassifierTest {
     "${secret}", "#{{secret}}", "$foo_bar",
     // Password-like values
     "password1234", "passwd",
+    // Leetspeak "password" variants with "@" that the "pass" substring misses
+    "p@ssword", "p@ssw0rd",
     // Boolean / null / scalar literals
     "undefined", "true", "null",
     // "your..." prefix


### PR DESCRIPTION
----
## Summary by Gitar

- **SecretClassifier improvements:**
    - Added regex `p[@a]ssw[o0]rd` to identify common leetspeak variants of "password".
    - Included `p@ssword` and `p@ssw0rd` in `SecretClassifierTest` to verify detection of leetspeak variants.

<sub>This will update automatically on new commits.</sub>