### PR TITLE
PREQ-7435 Fix release promote/publish version on workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,20 @@ on:
         required: true
       releaseId:
         type: string
-        description: Release ID
-        required: true
+        description: GitHub release ID (required for a full release; unused when publishPackagesOnly=true)
+        required: false
       dryRun:
         type: boolean
         description: Flag to enable the dry-run execution
         default: false
+      publishPackagesOnly:
+        type: boolean
+        description: Skip Maven/binaries release; only promote and publish npm/NuGet to public registries
+        default: false
 
 jobs:
   release:
+    if: ${{ github.event_name == 'release' || inputs.publishPackagesOnly != true }}
     permissions:
       id-token: write
       contents: write
@@ -39,6 +44,8 @@ jobs:
   # release above does not handle it (the .nupkg is published to the NuGet feed, not as a Maven artifact).
   promote-nuget:
     needs: [release]
+    # Run after a successful release, or when release was skipped via publishPackagesOnly.
+    if: ${{ !cancelled() && (needs.release.result == 'success' || needs.release.result == 'skipped') }}
     runs-on: sonar-xs-public
     name: Promote NuGet to releases
     permissions:
@@ -81,6 +88,8 @@ jobs:
   # release above does not handle it (the .tgz is published to the npm feed, not as a Maven artifact).
   promote-npm:
     needs: [release]
+    # Run after a successful release, or when release was skipped via publishPackagesOnly.
+    if: ${{ !cancelled() && (needs.release.result == 'success' || needs.release.result == 'skipped') }}
     runs-on: sonar-xs-public
     name: Promote npm to releases
     permissions:
@@ -217,4 +226,3 @@ jobs:
           # npm Trusted Publishing requires npm >= 11.5.1; GitHub-hosted runners may ship an older bundled npm.
           npm install -g npm@latest
           npm publish npm-release/*.tgz --access public --provenance
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           PROMOTER_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).PROMOTER_ACCESS_TOKEN }}
           # The release tag is the full 4-part version, e.g. 2.27.0.5000; the build number is its last segment.
-          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_VERSION: ${{ inputs.version || github.event.release.tag_name }}
         run: |
           set -euo pipefail
           BUILD_NAME="${GITHUB_REPOSITORY#*/}_nuget"
@@ -104,7 +104,7 @@ jobs:
         env:
           PROMOTER_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).PROMOTER_ACCESS_TOKEN }}
           # The release tag is the full 4-part version, e.g. 2.27.0.5000; the build number is its last segment.
-          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_VERSION: ${{ inputs.version || github.event.release.tag_name }}
         run: |
           set -euo pipefail
           BUILD_NAME="${GITHUB_REPOSITORY#*/}_npm"
@@ -147,7 +147,7 @@ jobs:
         shell: bash
         env:
           PROMOTER_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).PROMOTER_ACCESS_TOKEN }}
-          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_VERSION: ${{ inputs.version || github.event.release.tag_name }}
         run: |
           set -euo pipefail
           BUILD_NAME="${GITHUB_REPOSITORY#*/}_nuget"
@@ -197,7 +197,7 @@ jobs:
         env:
           PROMOTER_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).PROMOTER_ACCESS_TOKEN }}
           # The release tag is the full 4-part version, e.g. 2.27.0.5000; the build number is its last segment.
-          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_VERSION: ${{ inputs.version || github.event.release.tag_name }}
         run: |
           set -euo pipefail
           BUILD_NAME="${GITHUB_REPOSITORY#*/}_npm"


### PR DESCRIPTION
## Summary
- Promote npm/NuGet and publish-to-public-registry jobs only used `github.event.release.tag_name` for `RELEASE_VERSION`.
- On `workflow_dispatch` (e.g. automated release), that field is empty, so `build-promote` ran with an empty build number and failed with Artifactory `405 Method Not Allowed` ([run #29838652982](https://github.com/SonarSource/sonar-analyzer-commons/actions/runs/29838652982)).
- Align those jobs with the main release job: `inputs.version || github.event.release.tag_name`.
- Add `publishPackagesOnly` so a dispatch can skip Maven/binaries (`gh-action_release`) and only promote + publish npm/NuGet — needed to finish `2.29.0.5104` without re-releasing what already succeeded.

## How to finish 2.29.0.5104 (after merge, or from this branch)
```bash
gh workflow run sonar-release \
  --repo SonarSource/sonar-analyzer-commons \
  --ref fix/PREQ-7435-release-version-workflow-dispatch \
  -f version=2.29.0.5104 \
  -f publishPackagesOnly=true
```

## Test plan
- [ ] Re-dispatch with `publishPackagesOnly=true` and `version=2.29.0.5104` — release job skipped; promote + publish npm/NuGet run
- [ ] Confirm classic `release` published event still runs full release + promote/publish
- [ ] Confirm normal `workflow_dispatch` without `publishPackagesOnly` still runs the full release