### PR TITLE
PREQ-7435 Run publish jobs when release is skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,8 +207,6 @@ jobs:
         with:
           secrets: |
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-promoter access_token | PROMOTER_ACCESS_TOKEN;
-            # First publish of a new package cannot use Trusted Publishing alone (package must exist on npmjs).
-            # Vault token is still required until a Trusted Publisher is configured for subsequent releases.
             development/kv/data/npmjs sonartech_npm_token | NPM_TOKEN;
       - name: Download released npm package from Repox
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,4 +231,14 @@ jobs:
           set -euo pipefail
           # npm Trusted Publishing requires npm >= 11.5.1; GitHub-hosted runners may ship an older bundled npm.
           npm install -g npm@latest
-          npm publish npm-release/*.tgz --access public --provenance
+          # Use ./ prefix: without it, npm treats "npm-release/foo.tgz" as a github: shorthand (EALLOWGIT).
+          shopt -s nullglob
+          pkgs=(./npm-release/*.tgz)
+          if [[ ${#pkgs[@]} -eq 0 ]]; then
+            echo "::error::No .tgz found under ./npm-release"
+            exit 1
+          fi
+          for pkg in "${pkgs[@]}"; do
+            echo "Publishing ${pkg}"
+            npm publish "${pkg}" --access public --provenance
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,9 @@ jobs:
         with:
           secrets: |
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-promoter access_token | PROMOTER_ACCESS_TOKEN;
+            # First publish of a new package cannot use Trusted Publishing alone (package must exist on npmjs).
+            # Vault token is still required until a Trusted Publisher is configured for subsequent releases.
+            development/kv/data/npmjs sonartech_npm_token | NPM_TOKEN;
       - name: Download released npm package from Repox
         shell: bash
         env:
@@ -227,10 +230,14 @@ jobs:
       - name: Publish npm package to npmjs.org
         if: ${{ inputs.dryRun != true }}
         shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).NPM_TOKEN }}
         run: |
           set -euo pipefail
           # npm Trusted Publishing requires npm >= 11.5.1; GitHub-hosted runners may ship an older bundled npm.
           npm install -g npm@latest
+          # Auth for first publish / until Trusted Publisher is configured for this package.
+          printf '%s\n' "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > "${HOME}/.npmrc"
           # Use ./ prefix: without it, npm treats "npm-release/foo.tgz" as a github: shorthand (EALLOWGIT).
           shopt -s nullglob
           pkgs=(./npm-release/*.tgz)
@@ -241,5 +248,6 @@ jobs:
           for pkg in "${pkgs[@]}"; do
             echo "Publishing ${pkg}"
             # Build-style versions (e.g. 2.29.0-5104) are semver prereleases; npm requires --tag.
-            npm publish "${pkg}" --access public --provenance --tag latest
+            # Omit --provenance here: provenance is tied to Trusted Publishing OIDC; token publish is for bootstrap.
+            npm publish "${pkg}" --access public --tag latest
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,9 @@ jobs:
   # they depend on must also exist on the actual public registries, not just in RepoX.
   publish-nuget-public:
     needs: [ promote-nuget ]
+    # Explicit condition required: when `release` is skipped (publishPackagesOnly), GitHub skips
+    # downstream jobs that lack an if, even if promote-nuget succeeded.
+    if: ${{ !cancelled() && needs.promote-nuget.result == 'success' }}
     runs-on: sonar-xs-public
     name: Publish NuGet to nuget.org
     permissions:
@@ -182,6 +185,9 @@ jobs:
 
   publish-npm-public:
     needs: [ promote-npm ]
+    # Explicit condition required: when `release` is skipped (publishPackagesOnly), GitHub skips
+    # downstream jobs that lack an if, even if promote-npm succeeded.
+    if: ${{ !cancelled() && needs.promote-npm.result == 'success' }}
     runs-on: github-ubuntu-latest-s # npm Trusted Publishing requires a GitHub-hosted runner
     name: Publish npm to npmjs.org
     environment: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,5 +240,6 @@ jobs:
           fi
           for pkg in "${pkgs[@]}"; do
             echo "Publishing ${pkg}"
-            npm publish "${pkg}" --access public --provenance
+            # Build-style versions (e.g. 2.29.0-5104) are semver prereleases; npm requires --tag.
+            npm publish "${pkg}" --access public --provenance --tag latest
           done


### PR DESCRIPTION
## Summary
Follow-up to #461 so `publishPackagesOnly` can finish public registry publishes.

### Workflow fixes
- Explicit `if` on publish jobs so they run when `release` is skipped
- `npm publish ./…` (avoid EALLOWGIT github: shorthand)
- `--tag latest` for prerelease versions like `2.29.0-5104`
- Vault `development/kv/data/npmjs` token for bootstrap publish (Trusted Publishing cannot create a brand-new package)

### Status for `2.29.0.5104`
| Step | Status |
| --- | --- |
| Promote npm/NuGet to RepoX releases | Done |
| Publish npm to npmjs.org | **Blocked** — repo GitHub Vault role lacks `development/kv/data/npmjs`; Trusted Publisher not configured (and cannot bootstrap a new package) |
| Publish NuGet to nuget.org | **Blocked** — package missing required licenseUrl `https://licenses.nuget.org/LGPL-3.0-only` (packaging fix needed) |

### Next for npm
1. Grant Vault policy for `development/kv/data/npmjs` to `sonar-analyzer-commons` (Port self-service), **or** EngXP first-publish with the org token, then configure Trusted Publisher.
2. Re-dispatch `publishPackagesOnly=true` from `master` after merge.