### PR TITLE
PREQ-7434 Set NuGet licenseUrl for LGPL-3.0-only expression

### DIFF
--- a/sonar-analyzer-commons-configurations/src/main/packaging/nuget/sonar-analyzer-commons-configurations.nuspec
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/nuget/sonar-analyzer-commons-configurations.nuspec
@@ -7,6 +7,8 @@
     <owners>SonarSource</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">LGPL-3.0-only</license>
+    <!-- Required by nuget.org when a license expression is set (legacy clients). See https://aka.ms/invalidNuGetLicenseUrl -->
+    <licenseUrl>https://licenses.nuget.org/LGPL-3.0-only</licenseUrl>
     <projectUrl>https://github.com/SonarSource/sonar-analyzer-commons</projectUrl>
     <description>Shared analyzer configuration data (secret-exclusion regexes) generated from the sonar-analyzer-commons
       SecretClassifier, for use by non-JVM SonarSource analyzers. The payload is content/secret-patterns.json.</description>


### PR DESCRIPTION
## Summary
- NuGet.org rejected `SonarAnalyzer.CommonsConfigurations` with HTTP 400: when a license expression is specified, `<licenseUrl>` must be `https://licenses.nuget.org/LGPL-3.0-only` ([aka.ms/invalidNuGetLicenseUrl](https://aka.ms/invalidNuGetLicenseUrl)).
- Add the matching `<licenseUrl>` to the package nuspec so the next release can be published to nuget.org.
- Tracked in [PREQ-7434](https://sonarsource.atlassian.net/browse/PREQ-7434). Evidence: [workflow run](https://github.com/SonarSource/sonar-analyzer-commons/actions/runs/29907109509).

## Test plan
- [ ] Build produces a `.nupkg` whose nuspec includes both `<license type="expression">LGPL-3.0-only</license>` and `<licenseUrl>https://licenses.nuget.org/LGPL-3.0-only</licenseUrl>`
- [ ] After merge, cut a new release and confirm nuget.org push succeeds (re-push of 2.29.0.5104 is not sufficient)

[PREQ-7434]: https://sonarsource.atlassian.net/browse/PREQ-7434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ