### PR TITLE
ACOMMONS-104 Add required Readme to the Nuget package

### DIFF
--- a/sonar-analyzer-commons-configurations/src/main/assembly/nupkg.xml
+++ b/sonar-analyzer-commons-configurations/src/main/assembly/nupkg.xml
@@ -34,5 +34,10 @@
       <outputDirectory>content</outputDirectory>
       <destName>secret-patterns.json</destName>
     </file>
+    <file>
+      <source>${project.build.directory}/packaging/nuget/README.md</source>
+      <outputDirectory>./</outputDirectory>
+      <destName>README.md</destName>
+    </file>
   </files>
 </assembly>

--- a/sonar-analyzer-commons-configurations/src/main/packaging/nuget/README.md
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/nuget/README.md
@@ -1,0 +1,8 @@
+# SonarAnalyzer.CommonsConfigurations
+
+Shared analyzer configuration data (secret-exclusion regexes) generated from the sonar-analyzer-commons
+SecretClassifier, for use by non-JVM SonarSource analyzers.
+
+The payload is `content/secret-patterns.json`.
+
+See [SonarSource/sonar-analyzer-commons](https://github.com/SonarSource/sonar-analyzer-commons) for details.

--- a/sonar-analyzer-commons-configurations/src/main/packaging/nuget/[Content_Types].xml
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/nuget/[Content_Types].xml
@@ -4,4 +4,5 @@
   <Default Extension="psmdcp" ContentType="application/vnd.openxmlformats-package.core-properties+xml" />
   <Default Extension="nuspec" ContentType="application/octet" />
   <Default Extension="json" ContentType="application/json" />
+  <Default Extension="md" ContentType="text/markdown" />
 </Types>

--- a/sonar-analyzer-commons-configurations/src/main/packaging/nuget/sonar-analyzer-commons-configurations.nuspec
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/nuget/sonar-analyzer-commons-configurations.nuspec
@@ -10,6 +10,7 @@
     <!-- Required by nuget.org when a license expression is set (legacy clients). See https://aka.ms/invalidNuGetLicenseUrl -->
     <licenseUrl>https://licenses.nuget.org/LGPL-3.0-only</licenseUrl>
     <projectUrl>https://github.com/SonarSource/sonar-analyzer-commons</projectUrl>
+    <readme>README.md</readme>
     <description>Shared analyzer configuration data (secret-exclusion regexes) generated from the sonar-analyzer-commons
       SecretClassifier, for use by non-JVM SonarSource analyzers. The payload is content/secret-patterns.json.</description>
     <tags>sonarsource analyzer secrets configuration</tags>


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **NuGet configuration:**
    - Added `README.md` to the NuGet package via `nupkg.xml` assembly configuration.
    - Updated `sonar-analyzer-commons-configurations.nuspec` to include the `readme` file reference.
    - Registered `md` extension in `[Content_Types].xml` for proper package content handling.

<sub>This will update automatically on new commits.</sub>