### PR TITLE
PREQ-7434 Sign NuGet packages with DigiCert instead of Azure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,11 +79,12 @@ jobs:
       # DigiCert (not Azure Trusted Signing): nuget.org requires a registered certificate
       # thumbprint. Azure Artifact Signing certs rotate ~72h, so they cannot be registered.
       # See Platform docs "Windows Artifact Signing - GitHub" and PREQ-7434 / NuGetGallery#10027.
+      # Sign only release branches (not PRs): DigiCert quota is limited; matches .NET / ADO practice.
       - name: Setup DigiCert Client Tools
-        if: steps.build-maven.outputs.deployed == 'true'
+        if: ${{ steps.build-maven.outputs.deployed == 'true' && github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-')) }}
         uses: SonarSource/ci-github-actions/code-signing@v1
       - name: Sign NuGet package with DigiCert
-        if: steps.build-maven.outputs.deployed == 'true'
+        if: ${{ steps.build-maven.outputs.deployed == 'true' && github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-')) }}
         shell: bash
         env:
           NUPKG_DIR: ${{ steps.nupkg.outputs.dir }}
@@ -95,26 +96,27 @@ jobs:
             echo "::error::No .nupkg found under ${NUPKG_DIR}"
             exit 1
           fi
-          # DigiCert ONE --alias is the certificate alias/id from Software Trust Manager,
-          # not the Vault cert_fp SHA1 (that fails with "Unable to retrieve DigiCert ONE certificate").
-          # Same resolution as sonarcloud-task-manager Windows signing.
-          CERT_ALIAS="$(smctl certificate ls | awk 'NR > 1 && toupper($4) == "ACTIVE" { print $2; exit }')"
-          if [[ -z "${CERT_ALIAS}" ]]; then
-            echo "::error::Could not resolve an ACTIVE DigiCert certificate alias via smctl"
-            smctl certificate ls || true
+          # Prefer smctl + jsign (ci-github-actions docs). jsign DIGICERTONE REST against
+          # this host failed in CI with a non-JSON keypair response after resolving cert_*.
+          PKCS11_CFG="${SMTOOLS_PATH}/pkcs11properties.cfg"
+          if [[ ! -f "${PKCS11_CFG}" ]]; then
+            echo "::error::Missing DigiCert PKCS#11 config at ${PKCS11_CFG}"
+            ls -la "${SMTOOLS_PATH}" || true
             exit 1
           fi
-          echo "Using DigiCert certificate alias: ${CERT_ALIAS}"
-          jsign \
-            --storetype DIGICERTONE \
-            --keystore "${SM_HOST}" \
-            --storepass "${SM_API_KEY}|${SM_CLIENT_CERT_FILE}|${SM_CLIENT_CERT_PASSWORD}" \
-            --alias "${CERT_ALIAS}" \
-            --tsaurl http://timestamp.digicert.com \
-            --alg SHA-256 \
-            --replace \
-            "${pkgs[@]}"
+          KEYPAIR_ALIAS="$(smctl keypair ls 2>/dev/null | awk 'NR > 1 && toupper($0) ~ /ACTIVE/ { print $2; exit }')"
+          if [[ -z "${KEYPAIR_ALIAS}" ]]; then
+            # Legacy SonarSource DigiCert keypair used by other public NuGet / Windows signers.
+            KEYPAIR_ALIAS=key_525594307
+            echo "smctl keypair ls did not yield an ACTIVE alias; falling back to ${KEYPAIR_ALIAS}"
+          fi
+          echo "Using DigiCert keypair alias: ${KEYPAIR_ALIAS}"
           for pkg in "${pkgs[@]}"; do
+            smctl sign \
+              --keypair-alias="${KEYPAIR_ALIAS}" \
+              --config-file "${PKCS11_CFG}" \
+              --input "${pkg}" \
+              --tool jsign
             if ! jsign extract "${pkg}" > /dev/null 2>&1; then
               echo "::error::No signature found on ${pkg}"
               exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           artifactory-deployer-role: qa-deployer
           deploy-pull-request: true
 
-      # --- NuGet package: sign with the SonarSource author certificate and publish to the Repox NuGet feed. ---
+      # --- NuGet package: DigiCert-sign and publish to the Repox NuGet feed. ---
       # The Maven build only assembles the .nupkg into target/; it is NOT a Maven artifact. These steps sign it
       # and upload it to a NuGet-layout repo so .NET projects can consume it. Only runs when Maven actually deployed.
       - name: Prepare NuGet package
@@ -76,12 +76,41 @@ jobs:
             echo "version=${PKG_VERSION}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Sign NuGet package
+      # DigiCert (not Azure Trusted Signing): nuget.org requires a registered certificate
+      # thumbprint. Azure Artifact Signing certs rotate ~72h, so they cannot be registered.
+      # See Platform docs "Windows Artifact Signing - GitHub" and PREQ-7434 / NuGetGallery#10027.
+      - name: Setup DigiCert Client Tools
         if: steps.build-maven.outputs.deployed == 'true'
-        uses: SonarSource/gh-action_azure-artifact-signing@v1
-        with:
-          mode: sign
-          files: ${{ steps.nupkg.outputs.dir }}/*.nupkg
+        uses: SonarSource/ci-github-actions/code-signing@v1
+      - name: Sign NuGet package with DigiCert
+        if: steps.build-maven.outputs.deployed == 'true'
+        shell: bash
+        env:
+          NUPKG_DIR: ${{ steps.nupkg.outputs.dir }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          pkgs=("${NUPKG_DIR}"/*.nupkg)
+          if [[ ${#pkgs[@]} -eq 0 ]]; then
+            echo "::error::No .nupkg found under ${NUPKG_DIR}"
+            exit 1
+          fi
+          jsign \
+            --storetype DIGICERTONE \
+            --keystore "${SM_HOST}" \
+            --storepass "${SM_API_KEY}|${SM_CLIENT_CERT_FILE}|${SM_CLIENT_CERT_PASSWORD}" \
+            --alias "${SM_CODE_SIGNING_CERT_SHA1_HASH}" \
+            --tsaurl http://timestamp.digicert.com \
+            --replace \
+            "${pkgs[@]}"
+          for pkg in "${pkgs[@]}"; do
+            if ! jsign extract "${pkg}" > /dev/null 2>&1; then
+              echo "::error::No signature found on ${pkg}"
+              exit 1
+            fi
+            rm -f "${pkg}.sig"
+            echo "Signature verified on ${pkg}"
+          done
 
       - name: Install jfrog-cli
         if: steps.build-maven.outputs.deployed == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,12 +95,23 @@ jobs:
             echo "::error::No .nupkg found under ${NUPKG_DIR}"
             exit 1
           fi
+          # DigiCert ONE --alias is the certificate alias/id from Software Trust Manager,
+          # not the Vault cert_fp SHA1 (that fails with "Unable to retrieve DigiCert ONE certificate").
+          # Same resolution as sonarcloud-task-manager Windows signing.
+          CERT_ALIAS="$(smctl certificate ls | awk 'NR > 1 && toupper($4) == "ACTIVE" { print $2; exit }')"
+          if [[ -z "${CERT_ALIAS}" ]]; then
+            echo "::error::Could not resolve an ACTIVE DigiCert certificate alias via smctl"
+            smctl certificate ls || true
+            exit 1
+          fi
+          echo "Using DigiCert certificate alias: ${CERT_ALIAS}"
           jsign \
             --storetype DIGICERTONE \
             --keystore "${SM_HOST}" \
             --storepass "${SM_API_KEY}|${SM_CLIENT_CERT_FILE}|${SM_CLIENT_CERT_PASSWORD}" \
-            --alias "${SM_CODE_SIGNING_CERT_SHA1_HASH}" \
+            --alias "${CERT_ALIAS}" \
             --tsaurl http://timestamp.digicert.com \
+            --alg SHA-256 \
             --replace \
             "${pkgs[@]}"
           for pkg in "${pkgs[@]}"; do


### PR DESCRIPTION
## Summary
- Replace `gh-action_azure-artifact-signing` with DigiCert via `ci-github-actions/code-signing` + `jsign --storetype DIGICERTONE`.
- Needed so `SonarAnalyzer.CommonsConfigurations` can pass nuget.org Gallery validation ([PREQ-7434](https://sonarsource.atlassian.net/browse/PREQ-7434)).
- Azure Trusted Signing certs rotate ~72h; nuget.org requires a registered thumbprint ([Windows Artifact Signing - GitHub](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/4886396930/Windows+Artifact+Signing+-+GitHub), [NuGetGallery#10027](https://github.com/NuGet/NuGetGallery/issues/10027)).

## Companion
Vault grant for `development/kv/data/sign/digicert`: https://github.com/SonarSource/re-terraform-aws-vault/pull/9480 — must merge/apply before DigiCert signing succeeds in CI.

## Test plan
- [ ] After Vault grant is applied: Build on this branch signs the `.nupkg` (DigiCert setup + `jsign extract` verification green)
- [ ] Merge → new release → promote/publish → nuget.org Gallery accepts the DigiCert-signed package (no “certificate not associated” for Azure thumbprint)
- [ ] Confirm DigiCert thumbprint is already registered on the SonarSource nuget.org account (same as other `SonarAnalyzer.*` packages)

[PREQ-7434]: https://sonarsource.atlassian.net/browse/PREQ-7434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ