### PR TITLE
PREQ-7434 Fix DigiCert NuGet signing after smctl no-op

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,9 +52,11 @@ jobs:
       # --- NuGet package: DigiCert-sign and publish to the Repox NuGet feed. ---
       # The Maven build only assembles the .nupkg into target/; it is NOT a Maven artifact. These steps sign it
       # and upload it to a NuGet-layout repo so .NET projects can consume it. Only runs when Maven actually deployed.
+      # Also runs for workflow_dispatch forceDigicertSign: feature branches only mvn verify (deployed=false)
+      # but still produce the nupkg under target/, which is enough to exercise DigiCert before merge.
       - name: Prepare NuGet package
         id: nupkg
-        if: steps.build-maven.outputs.deployed == 'true'
+        if: ${{ steps.build-maven.outputs.deployed == 'true' || inputs.forceDigicertSign == true }}
         shell: bash
         env:
           PROJECT_VERSION: ${{ steps.build-maven.outputs.project-version }}
@@ -86,13 +88,13 @@ jobs:
       # See Platform docs "Windows Artifact Signing - GitHub" and PREQ-7434 / NuGetGallery#10027.
       # Sign only release branches (not PRs), or workflow_dispatch with forceDigicertSign=true for pre-merge tests.
       - name: Setup DigiCert Client Tools
-        if: ${{ steps.build-maven.outputs.deployed == 'true' && (inputs.forceDigicertSign == true || (github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-')))) }}
+        if: ${{ inputs.forceDigicertSign == true || (steps.build-maven.outputs.deployed == 'true' && github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-'))) }}
         uses: SonarSource/ci-github-actions/code-signing@v1
         with:
           # 7.2 DIGICERTONE keypair fetch returned HTML/non-JSON in CI; use a newer jsign.
           jsign-version: "7.5"
       - name: Sign NuGet package with DigiCert
-        if: ${{ steps.build-maven.outputs.deployed == 'true' && (inputs.forceDigicertSign == true || (github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-')))) }}
+        if: ${{ inputs.forceDigicertSign == true || (steps.build-maven.outputs.deployed == 'true' && github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-'))) }}
         shell: bash
         env:
           NUPKG_DIR: ${{ steps.nupkg.outputs.dir }}
@@ -269,6 +271,8 @@ jobs:
 
   promote:
     needs: [ build ]
+    # Skip on DigiCert-only pre-merge tests (feature-branch dispatch has nothing to promote).
+    if: ${{ inputs.forceDigicertSign != true }}
     runs-on: sonar-xs
     name: Promote
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Setup DigiCert Client Tools
         if: ${{ steps.build-maven.outputs.deployed == 'true' && github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-')) }}
         uses: SonarSource/ci-github-actions/code-signing@v1
+        with:
+          # 7.2 DIGICERTONE keypair fetch returned HTML/non-JSON in CI; use a newer jsign.
+          jsign-version: "7.5"
       - name: Sign NuGet package with DigiCert
         if: ${{ steps.build-maven.outputs.deployed == 'true' && github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-')) }}
         shell: bash
@@ -96,33 +99,88 @@ jobs:
             echo "::error::No .nupkg found under ${NUPKG_DIR}"
             exit 1
           fi
-          # Prefer smctl + jsign (ci-github-actions docs). jsign DIGICERTONE REST against
-          # this host failed in CI with a non-JSON keypair response after resolving cert_*.
           PKCS11_CFG="${SMTOOLS_PATH}/pkcs11properties.cfg"
           if [[ ! -f "${PKCS11_CFG}" ]]; then
             echo "::error::Missing DigiCert PKCS#11 config at ${PKCS11_CFG}"
             ls -la "${SMTOOLS_PATH}" || true
             exit 1
           fi
-          KEYPAIR_ALIAS="$(smctl keypair ls 2>/dev/null | awk 'NR > 1 && toupper($0) ~ /ACTIVE/ { print $2; exit }')"
-          if [[ -z "${KEYPAIR_ALIAS}" ]]; then
-            # Legacy SonarSource DigiCert keypair used by other public NuGet / Windows signers.
-            KEYPAIR_ALIAS=key_525594307
-            echo "smctl keypair ls did not yield an ACTIVE alias; falling back to ${KEYPAIR_ALIAS}"
+
+          echo "=== DigiCert certificates ==="
+          smctl certificate ls || true
+          echo "=== DigiCert keypairs ==="
+          smctl keypair ls || true
+
+          # DigiCert ONE certificate alias (e.g. cert_*), not Vault SHA1 and not a guessed key_* .
+          CERT_ALIAS="$(smctl certificate ls | awk 'NR > 1 && toupper($4) == "ACTIVE" { print $2; exit }')"
+          KEYPAIR_ALIAS="$(smctl keypair ls | awk 'NR > 1 && toupper($0) ~ /ACTIVE/ { print $2; exit }')"
+          if [[ -z "${CERT_ALIAS}" && -z "${KEYPAIR_ALIAS}" ]]; then
+            echo "::error::Could not resolve DigiCert certificate or keypair alias via smctl"
+            exit 1
           fi
-          echo "Using DigiCert keypair alias: ${KEYPAIR_ALIAS}"
-          for pkg in "${pkgs[@]}"; do
-            smctl sign \
-              --keypair-alias="${KEYPAIR_ALIAS}" \
-              --config-file "${PKCS11_CFG}" \
-              --input "${pkg}" \
-              --tool jsign
-            if ! jsign extract "${pkg}" > /dev/null 2>&1; then
-              echo "::error::No signature found on ${pkg}"
-              exit 1
+
+          sign_one() {
+            local pkg="$1"
+            local alias="$2"
+            local mode="$3"
+            echo "Signing ${pkg} with ${mode} alias=${alias}"
+            case "${mode}" in
+              DIGICERTONE)
+                jsign \
+                  --storetype DIGICERTONE \
+                  --keystore "${SM_HOST}" \
+                  --storepass "${SM_API_KEY}|${SM_CLIENT_CERT_FILE}|${SM_CLIENT_CERT_PASSWORD}" \
+                  --alias "${alias}" \
+                  --tsaurl http://timestamp.digicert.com \
+                  --alg SHA-256 \
+                  --replace \
+                  "${pkg}"
+                ;;
+              PKCS11)
+                jsign \
+                  --storetype PKCS11 \
+                  --keystore "${PKCS11_CFG}" \
+                  --storepass NONE \
+                  --alias "${alias}" \
+                  --tsaurl http://timestamp.digicert.com \
+                  --alg SHA-256 \
+                  --replace \
+                  "${pkg}"
+                ;;
+              *)
+                echo "::error::Unknown sign mode ${mode}"
+                return 1
+                ;;
+            esac
+          }
+
+          verify_one() {
+            local pkg="$1"
+            if jsign extract "${pkg}" > /dev/null 2>&1; then
+              rm -f "${pkg}.sig"
+              echo "Signature verified on ${pkg}"
+              return 0
             fi
             rm -f "${pkg}.sig"
-            echo "Signature verified on ${pkg}"
+            return 1
+          }
+
+          for pkg in "${pkgs[@]}"; do
+            signed=0
+            # Prefer DigiCert ONE REST with certificate alias (same as sonarcloud-task-manager).
+            if [[ -n "${CERT_ALIAS}" ]] && sign_one "${pkg}" "${CERT_ALIAS}" DIGICERTONE && verify_one "${pkg}"; then
+              signed=1
+            # PKCS11 with keypair alias (smctl-managed local module).
+            elif [[ -n "${KEYPAIR_ALIAS}" ]] && sign_one "${pkg}" "${KEYPAIR_ALIAS}" PKCS11 && verify_one "${pkg}"; then
+              signed=1
+            # PKCS11 sometimes exposes the certificate alias instead of key_*.
+            elif [[ -n "${CERT_ALIAS}" ]] && sign_one "${pkg}" "${CERT_ALIAS}" PKCS11 && verify_one "${pkg}"; then
+              signed=1
+            fi
+            if [[ "${signed}" -ne 1 ]]; then
+              echo "::error::Failed to DigiCert-sign ${pkg} (tried DIGICERTONE/PKCS11 with resolved aliases)"
+              exit 1
+            fi
           done
 
       - name: Install jfrog-cli

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ on:
   pull_request:
   merge_group:
   workflow_dispatch:
+    inputs:
+      forceDigicertSign:
+        type: boolean
+        description: Force DigiCert NuGet signing (test outside master/branch-*; uses DigiCert quota)
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -79,15 +84,15 @@ jobs:
       # DigiCert (not Azure Trusted Signing): nuget.org requires a registered certificate
       # thumbprint. Azure Artifact Signing certs rotate ~72h, so they cannot be registered.
       # See Platform docs "Windows Artifact Signing - GitHub" and PREQ-7434 / NuGetGallery#10027.
-      # Sign only release branches (not PRs): DigiCert quota is limited; matches .NET / ADO practice.
+      # Sign only release branches (not PRs), or workflow_dispatch with forceDigicertSign=true for pre-merge tests.
       - name: Setup DigiCert Client Tools
-        if: ${{ steps.build-maven.outputs.deployed == 'true' && github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-')) }}
+        if: ${{ steps.build-maven.outputs.deployed == 'true' && (inputs.forceDigicertSign == true || (github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-')))) }}
         uses: SonarSource/ci-github-actions/code-signing@v1
         with:
           # 7.2 DIGICERTONE keypair fetch returned HTML/non-JSON in CI; use a newer jsign.
           jsign-version: "7.5"
       - name: Sign NuGet package with DigiCert
-        if: ${{ steps.build-maven.outputs.deployed == 'true' && github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-')) }}
+        if: ${{ steps.build-maven.outputs.deployed == 'true' && (inputs.forceDigicertSign == true || (github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-')))) }}
         shell: bash
         env:
           NUPKG_DIR: ${{ steps.nupkg.outputs.dir }}


### PR DESCRIPTION
## Summary
- Master DigiCert sign failed after #465: [run 29926180130](https://github.com/SonarSource/sonar-analyzer-commons/actions/runs/29926180130) — `smctl keypair ls` empty → stale `key_525594307` fallback → `smctl sign --tool jsign` left no `jsign extract`-detectable signature.
- Resolve ACTIVE certificate/keypair aliases from `smctl` (no blind keypair fallback).
- Bump jsign to 7.5; sign via DigiCert ONE (`DIGICERTONE` + cert alias), with PKCS11 fallbacks.
- Tracked in [PREQ-7434](https://sonarsource.atlassian.net/browse/PREQ-7434).

## Test plan
- [ ] Merge to master → Build DigiCert step succeeds (`Signature verified on …nupkg`)
- [ ] PR Build still skips DigiCert (release-branch-only condition unchanged)
- [ ] Subsequent nuget.org publish uses DigiCert-signed package (Gallery accepts registered DigiCert thumbprint)

[PREQ-7434]: https://sonarsource.atlassian.net/browse/PREQ-7434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ