### PR TITLE
ACOMMONS-110 Remove duplicate regex from Secret Classifier

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -106,8 +106,6 @@ public final class SecretClassifier {
       "^your",
       // Same character 4 times in a row, e.g. "abbbbc"
       "(?<char>[\\w\\*\\.])\\k<char>{3}",
-      // Same character repeated from start to end, e.g. "aa", "111111"
-      "^(?<repeated>.)\\k<repeated>*+$",
       // A secret being masked or shortened, e.g. "1fj28...askn3i"
       "\\.\\.\\."),
 

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -105,7 +105,7 @@ public final class SecretClassifier {
       // Starts with "your", e.g. "yourpassword", "your_super_secret"
       "^your",
       // Same character 4 times in a row, e.g. "abbbbc"
-      "(?<char>[\\w\\*\\.])\\k<char>{3}",
+      "(?<repeated>.)\\k<repeated>{3}",
       // A secret being masked or shortened, e.g. "1fj28...askn3i"
       "\\.\\.\\."),
 


### PR DESCRIPTION
This PR removes an unnecessary regex from the Fake Value group of the Secret Classifier.
Since we have a check for min length 5, the regular expression detecting a secret that is only consisting of one character is not matching any cases that are not also detected by `"(?<char>[\\w\\*\\.])\\k<char>{3}"`.