### PR TITLE
CLP-242 PullRequestClosed: Add autodetect-lowest fix-version

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -26,3 +26,4 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          fix-version: autodetect-lowest


### PR DESCRIPTION
Part of CLP-241

----
## Summary by Gitar

- **CI/CD configuration:**
    - Added `fix-version: autodetect-lowest` parameter to the `PullRequestClosed` workflow in `.github/workflows/PullRequestClosed.yml`

<sub>This will update automatically on new commits.</sub>