### PR TITLE
APPSEC-3539 Add www.eclipse.org to CleartextProtocolFilter's namespace authority list

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -142,7 +142,9 @@ public final class CleartextProtocolFilter {
     // GraphML
     "^graphml\\.graphdrawing\\.org|" +
     // JSON Schema
-    "^json-schema\\.org" +
+    "^json-schema\\.org|" +
+    // Eclipse EMF/Ecore
+    "^www\\.eclipse\\.org" +
     ")(?=:|$)", Pattern.CASE_INSENSITIVE);
 
   // --- IANA-reserved documentation / placeholder domains --------------------------------

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -207,6 +207,7 @@ class CleartextProtocolFilterTest {
       "http://docbook.org/ns/docbook",
       "http://graphml.graphdrawing.org/graphml",
       "http://json-schema.org/draft-07/schema",
+      "http://www.eclipse.org/emf/2002/Ecore",
 
       // Case insensitivity and surrounding whitespace
       "HTTP://LOCALHOST:8080",


### PR DESCRIPTION
## Summary
- Adds `www.eclipse.org` to `CleartextProtocolFilter`'s namespace-URI authority list, alongside existing entries like `www.w3.org`, `schemas.xmlsoap.org`, `docs.oasis-open.org`.
- `www.eclipse.org` is used as the XML namespace authority for Eclipse EMF/Ecore (e.g. `http://www.eclipse.org/emf/2002/Ecore`), which S5332 was flagging as a false-positive cleartext-protocol violation.

Fixes https://sonarsource.atlassian.net/browse/APPSEC-3539 (blocks NET-3894).

## Test plan
- [x] Added `http://www.eclipse.org/emf/2002/Ecore` to `CleartextProtocolFilterTest#safeUris`
- [x] `mvn -pl commons -am test -Dtest=CleartextProtocolFilterTest` — 181 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)