### PR TITLE
SONARIAC-3061 Treat single-label hostnames as safe in CleartextProtocolFilter

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -277,15 +277,15 @@ public final class CleartextProtocolFilter {
     if (host == null) {
       return false;
     }
-    return isSafeHost(host) || isSingleLabelHost(host);
+    return isSafeHost(host);
   }
 
   private static boolean isSafeHost(String host) {
-    return isInternalHost(host) || isNamespaceUriAuthority(host) || isDocumentationHost(host);
+    return isInternalHost(host) || isNamespaceUriAuthority(host) || isDocumentationHost(host) || isSingleLabelHost(host);
   }
 
   // Single-integer IPv4 literal written in hexadecimal, e.g. 0x7f000001 (== 127.0.0.1).
-  private static final Pattern HEX_IP_LITERAL = Pattern.compile("^0[xX][0-9a-fA-F]+$");
+  private static final Pattern HEX_IP_LITERAL = Pattern.compile("^0[xX][0-9a-fA-F]++$");
 
   // Single-label hostnames (no dot) cannot resolve on the public internet; excludes IPv6
   // literals ("[...]") and numeric IP literals (decimal, e.g. 2130706433, and hexadecimal,

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -284,17 +284,22 @@ public final class CleartextProtocolFilter {
     return isInternalHost(host) || isNamespaceUriAuthority(host) || isDocumentationHost(host);
   }
 
+  // Single-integer IPv4 literal written in hexadecimal, e.g. 0x7f000001 (== 127.0.0.1).
+  private static final Pattern HEX_IP_LITERAL = Pattern.compile("^0[xX][0-9a-fA-F]+$");
+
   // Single-label hostnames (no dot) cannot resolve on the public internet; excludes IPv6
-  // literals ("[...]") and all-digit hosts, which are IP addresses rather than DNS names.
+  // literals ("[...]") and numeric IP literals (decimal, e.g. 2130706433, and hexadecimal,
+  // e.g. 0x7f000001 — octal single-integer literals are all-digit and match the decimal case
+  // too), which are IP addresses rather than DNS names.
   // Only applied to hosts parsed by java.net.URI: the lenient fallback in isSafeWithoutTls(String)
   // can extract a truncated fake "host" from malformed input (e.g. a URL containing a space),
   // and that value must not be trusted by this rule.
   private static boolean isSingleLabelHost(String host) {
-    return !host.isEmpty() && !host.startsWith("[") && host.indexOf('.') < 0 && !isAllDigits(host);
+    return !host.isEmpty() && !host.startsWith("[") && host.indexOf('.') < 0 && !isNumericIpLiteral(host);
   }
 
-  private static boolean isAllDigits(String host) {
-    return host.chars().allMatch(Character::isDigit);
+  private static boolean isNumericIpLiteral(String host) {
+    return host.chars().allMatch(Character::isDigit) || HEX_IP_LITERAL.matcher(host).matches();
   }
 
   private static boolean isInternalHost(String host) {

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -279,10 +279,6 @@ public final class CleartextProtocolFilter {
     if (host == null) {
       return false;
     }
-    // isSingleLabelHost is deliberately called here rather than folded into isSafeHost: isSafeHost
-    // is also used by the lenient string-fallback path in isSafeWithoutTls(String), which can
-    // extract a truncated fake "host" from malformed input (e.g. a URL like http://user:pass@${placeholder})
-    // that must not be trusted by this rule.
     return isSafeHost(host) || isSingleLabelHost(host);
   }
 

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -279,8 +279,8 @@ public final class CleartextProtocolFilter {
     }
     // isSingleLabelHost is deliberately called here rather than folded into isSafeHost: isSafeHost
     // is also used by the lenient string-fallback path in isSafeWithoutTls(String), which can
-    // extract a truncated fake "host" from malformed input (e.g. a URL containing a space) that
-    // must not be trusted by this rule. See isSingleLabelHost for details.
+    // extract a truncated fake "host" from malformed input (e.g. a URL like http://user:pass@${placeholder})
+    // that must not be trusted by this rule.
     return isSafeHost(host) || isSingleLabelHost(host);
   }
 

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -277,11 +277,15 @@ public final class CleartextProtocolFilter {
     if (host == null) {
       return false;
     }
-    return isSafeHost(host);
+    // isSingleLabelHost is deliberately called here rather than folded into isSafeHost: isSafeHost
+    // is also used by the lenient string-fallback path in isSafeWithoutTls(String), which can
+    // extract a truncated fake "host" from malformed input (e.g. a URL containing a space) that
+    // must not be trusted by this rule. See isSingleLabelHost for details.
+    return isSafeHost(host) || isSingleLabelHost(host);
   }
 
   private static boolean isSafeHost(String host) {
-    return isInternalHost(host) || isNamespaceUriAuthority(host) || isDocumentationHost(host) || isSingleLabelHost(host);
+    return isInternalHost(host) || isNamespaceUriAuthority(host) || isDocumentationHost(host);
   }
 
   // Single-integer IPv4 literal written in hexadecimal, e.g. 0x7f000001 (== 127.0.0.1).
@@ -291,9 +295,6 @@ public final class CleartextProtocolFilter {
   // literals ("[...]") and numeric IP literals (decimal, e.g. 2130706433, and hexadecimal,
   // e.g. 0x7f000001 — octal single-integer literals are all-digit and match the decimal case
   // too), which are IP addresses rather than DNS names.
-  // Only applied to hosts parsed by java.net.URI: the lenient fallback in isSafeWithoutTls(String)
-  // can extract a truncated fake "host" from malformed input (e.g. a URL containing a space),
-  // and that value must not be trusted by this rule.
   private static boolean isSingleLabelHost(String host) {
     return !host.isEmpty() && !host.startsWith("[") && host.indexOf('.') < 0 && !isNumericIpLiteral(host);
   }

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -69,6 +69,8 @@ public final class CleartextProtocolFilter {
     "^localhost|" +
     // IPv4 loopback (127.0.0.0/8) — 2–4 octet forms (127.1, 127.0.1, 127.0.0.1)
     "^127(?:\\.\\d+){1,3}|" +
+    // IPv4 loopback (127.0.0.0/8) written as a single hexadecimal literal (0x7f000000-0x7fffffff)
+    "^0x7f[0-9a-f]{6}|" +
     // IPv6 loopback (::1)
     "^\\[(?:0*:){7}:?0*1\\]|^\\[::1\\]|" +
     // IPv4 link-local (169.254.0.0/16, RFC 3927) — AWS/Azure/GCP/OCI IMDS

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -51,6 +51,9 @@ import java.util.stream.Collectors;
  *       {@code example.net}, and {@code example.org} and their subdomains, plus the
  *       reserved TLDs {@code .example}, {@code .test}, and {@code .localhost} (RFC 6761).
  *       Their use in source code is almost always a placeholder, not a real connection.</li>
+ *   <li><b>Single-label hostnames</b> — hostnames with no dot (e.g. {@code my-service}),
+ *       other than IP addresses. These cannot resolve on the public internet and are
+ *       typically Kubernetes/Docker Compose service names or other intranet hosts.</li>
  * </ul>
  * <p>
  * Usage: extract the raw URL string from the AST node and call {@link #isSafeWithoutTls(String)}
@@ -274,11 +277,24 @@ public final class CleartextProtocolFilter {
     if (host == null) {
       return false;
     }
-    return isSafeHost(host);
+    return isSafeHost(host) || isSingleLabelHost(host);
   }
 
   private static boolean isSafeHost(String host) {
     return isInternalHost(host) || isNamespaceUriAuthority(host) || isDocumentationHost(host);
+  }
+
+  // Single-label hostnames (no dot) cannot resolve on the public internet; excludes IPv6
+  // literals ("[...]") and all-digit hosts, which are IP addresses rather than DNS names.
+  // Only applied to hosts parsed by java.net.URI: the lenient fallback in isSafeWithoutTls(String)
+  // can extract a truncated fake "host" from malformed input (e.g. a URL containing a space),
+  // and that value must not be trusted by this rule.
+  private static boolean isSingleLabelHost(String host) {
+    return !host.isEmpty() && !host.startsWith("[") && host.indexOf('.') < 0 && !isAllDigits(host);
+  }
+
+  private static boolean isAllDigits(String host) {
+    return host.chars().allMatch(Character::isDigit);
   }
 
   private static boolean isInternalHost(String host) {

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -211,6 +211,13 @@ class CleartextProtocolFilterTest {
       "http://www.mulesoft.org/schema/mule/core",
       "http://www.mulesoft.org/schema/mule/http",
 
+      // Single-label hostnames — cannot resolve on the public internet
+      "http://estimate-translations-dev/meanings",
+      "http://estimate-globalization-localization-dev/",
+      "http://my-service/path",
+      "http://my-service:8080/path",
+      "ws://my-service",
+
       // Case insensitivity and surrounding whitespace
       "HTTP://LOCALHOST:8080",
       "FTP://127.0.0.1",
@@ -257,7 +264,9 @@ class CleartextProtocolFilterTest {
       // Documentation domain
       URI.create("http://example.com/path"),
       URI.create("http://api.example.com/v1"),
-      URI.create("http://myapi.test")
+      URI.create("http://myapi.test"),
+      // Single-label hostname
+      URI.create("http://my-service/path")
     );
   }
 
@@ -276,7 +285,10 @@ class CleartextProtocolFilterTest {
       URI.create("http://localhost@evil.com"),
       URI.create("http://www.w3.org@evil.com"),
       // Opaque URI — http scheme but no host component (getHost() == null)
-      URI.create("http:not-hierarchical")
+      URI.create("http:not-hierarchical"),
+      // Single-label host exclusions — IP addresses, not DNS names
+      URI.create("http://2130706433"),
+      URI.create("http://[2001:db8::1]")
     );
   }
 
@@ -336,7 +348,11 @@ class CleartextProtocolFilterTest {
 
       // Malformed — cannot be parsed as a URI (URISyntaxException → false)
       "http://foo bar.com",
-      "http://[unclosed"
+      "http://[unclosed",
+
+      // Single-label host exclusions — IP addresses, not DNS names
+      "http://2130706433/",
+      "http://[2001:db8::1]/path"
     );
   }
 }

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -288,7 +288,9 @@ class CleartextProtocolFilterTest {
       URI.create("http:not-hierarchical"),
       // Single-label host exclusions — IP addresses, not DNS names
       URI.create("http://2130706433"),
-      URI.create("http://[2001:db8::1]")
+      URI.create("http://[2001:db8::1]"),
+      URI.create("http://0x7f000001"),
+      URI.create("http://0X7F000001")
     );
   }
 
@@ -352,7 +354,9 @@ class CleartextProtocolFilterTest {
 
       // Single-label host exclusions — IP addresses, not DNS names
       "http://2130706433/",
-      "http://[2001:db8::1]/path"
+      "http://[2001:db8::1]/path",
+      "http://0x7f000001/",
+      "http://0X7F000001/"
     );
   }
 }

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -216,6 +216,11 @@ class CleartextProtocolFilterTest {
       "http://local-kubernetes-hostname:8080/something",
       "ws://my-service",
 
+      // IPv4 loopback (127.0.0.0/8) written as a single hexadecimal literal
+      "http://0x7f000001/",
+      "http://0X7F000001/",
+      "http://0x7fffffff/",
+
       // Case insensitivity and surrounding whitespace
       "HTTP://LOCALHOST:8080",
       "FTP://127.0.0.1",
@@ -286,9 +291,9 @@ class CleartextProtocolFilterTest {
       URI.create("http:not-hierarchical"),
       // Single-label host exclusions — IP addresses, not DNS names
       URI.create("http://2130706433"),
-      URI.create("http://[2001:db8::1]"),
-      URI.create("http://0x7f000001"),
-      URI.create("http://0X7F000001")
+      // 8.8.8.8 as hexadecimal literal
+      URI.create("http://0x08080808"),
+      URI.create("http://[2001:db8::1]")
     );
   }
 
@@ -352,9 +357,7 @@ class CleartextProtocolFilterTest {
 
       // Single-label host exclusions — IP addresses, not DNS names
       "http://2130706433/",
-      "http://[2001:db8::1]/path",
-      "http://0x7f000001/",
-      "http://0X7F000001/"
+      "http://[2001:db8::1]/path"
     );
   }
 }

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -212,10 +212,8 @@ class CleartextProtocolFilterTest {
       "http://www.mulesoft.org/schema/mule/http",
 
       // Single-label hostnames — cannot resolve on the public internet
-      "http://estimate-translations-dev/meanings",
-      "http://estimate-globalization-localization-dev/",
-      "http://my-service/path",
-      "http://my-service:8080/path",
+      "http://local-kubernetes-hostname/something",
+      "http://local-kubernetes-hostname:8080/something",
       "ws://my-service",
 
       // Case insensitivity and surrounding whitespace


### PR DESCRIPTION
## Summary
- S5332 raised false positives on single-label HTTP hostnames (e.g. `http://estimate-translations-dev/meanings`) — Kubernetes/Docker Compose service names that cannot resolve on the public internet.
- `CleartextProtocolFilter.isSafeWithoutTls()` now treats single-label hostnames (no dot) as safe, generalising the existing `localhost` special case. Excludes IPv6 literals (`[...]`) and numeric IP literals — decimal (e.g. `2130706433`) and hexadecimal (e.g. `0x7f000001`) — which are IP addresses rather than DNS names. Octal single-integer literals are already covered since they're all decimal digits.
- Scoped to hosts parsed strictly via `java.net.URI#getHost()` only (kept out of the shared `isSafeHost` helper). The lenient string-fallback path (used for template placeholders / underscore hostnames) is untouched, since it can extract a truncated fake host from malformed input (e.g. `http://foo bar.com` → `foo`) that must not be trusted by this rule.

Jira: SONARIAC-3061

## Test plan
- [x] Added parameterized cases for single-label hostnames to `safeUrls`/`safeUris`
- [x] Added exclusion cases (decimal-IP, hexadecimal-IP, public IPv6 literal) to `notSafeUrls`/`notSafeUris`
- [x] `mvn -pl commons test -Dtest=CleartextProtocolFilterTest` passes