### PR TITLE
ACOMMONS-130 Bump build JDK from Java 17 to Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <gitRepositoryName>sonar-analyzer-commons</gitRepositoryName>
     <artifactsToPublish>${project.groupId}:sonar-analyzer-commons:jar,${project.groupId}:sonar-analyzer-test-commons:jar,${project.groupId}:sonar-analyzer-recognizers:jar,${project.groupId}:sonar-xml-parsing:jar,${project.groupId}:test-sonar-xml-parsing:jar,${project.groupId}:sonar-regex-parsing:jar,${project.groupId}:sonar-analyzer-commons-configurations:json</artifactsToPublish>
     <!-- this property configures the settings in parent pom -->
-    <jdk.min.version>17</jdk.min.version>
+    <jdk.min.version>21</jdk.min.version>
     <maven.compiler.release>${jdk.min.version}</maven.compiler.release>
   </properties>
 


### PR DESCRIPTION
## Summary

Found via an org-wide Java-version audit: this repo's root `pom.xml` still declared `jdk.min.version` as `17`, while `mise.toml` was already pinned to JDK 21.

- `jdk.min.version` drives `maven.compiler.release` in the root pom, and all 8 sub-modules inherit it with no per-module override.
- Bumped `jdk.min.version` from `17` to `21` so the Maven compiler release target matches the JDK the build actually runs on.

No other files were changed.