### PR TITLE
ACOMMONS-131 Recognize kebab-case cloud resource identifiers as non-secrets

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -187,7 +187,7 @@ public final class SecretClassifier {
       // Stopgap: such values may instead be excluded by ignoring lockfiles by path.
       "^v?\\d++(?:\\.\\d++)++(?:\\([^()]*+\\))++$",
       // Kebab-case cloud-resource identifiers following a naming convention, ending in a short region/environment-style
-      // abbreviation plus a zero-padded instance number, e.g. "srv-creds-dbac-dsp-dev-uks-001". At least 5 lowercase
+      // abbreviation plus a zero-padded instance number. At least 5 lowercase
       // alphanumeric segments are required so the shape stays specific: a high-entropy secret essentially never has
       // this many hyphen-separated segments capped by a short alpha suffix and a padded numeric instance id.
       "^[a-z][a-z0-9]*+(?:-[a-z0-9]++){2,}-[a-z]{2,4}-\\d{2,4}$"));

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -185,7 +185,12 @@ public final class SecretClassifier {
         + "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
       // Resolved / peer-annotated version strings from package lockfiles, e.g. "4.0.9(@types/node@22.13.4)".
       // Stopgap: such values may instead be excluded by ignoring lockfiles by path.
-      "^v?\\d++(?:\\.\\d++)++(?:\\([^()]*+\\))++$"));
+      "^v?\\d++(?:\\.\\d++)++(?:\\([^()]*+\\))++$",
+      // Kebab-case cloud-resource identifiers following a naming convention, ending in a short region/environment-style
+      // abbreviation plus a zero-padded instance number, e.g. "srv-creds-dbac-dsp-dev-uks-001". At least 5 lowercase
+      // alphanumeric segments are required so the shape stays specific: a high-entropy secret essentially never has
+      // this many hyphen-separated segments capped by a short alpha suffix and a padded numeric instance id.
+      "^[a-z][a-z0-9]*+(?:-[a-z0-9]++){2,}-[a-z]{2,4}-\\d{2,4}$"));
 
   // Flattened once: isKnownNonSecret is on every check's hot path, so avoid re-flattening PATTERN_GROUPS per call.
   private static final List<Pattern> ALL_PATTERNS = PATTERN_GROUPS.stream()

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
@@ -100,7 +100,10 @@ class SecretClassifierTest {
   static final List<String> STRUCTURED_FORMAT_SAMPLES = List.of(
     "/var/keys/gsa-key.json",
     "v1.2.3", ">=1.0.0", "~1.4.5-alpha",                // semver variants
-    "4.0.9(@types/node@22.13.4)");                       // peer-annotated lockfile version (non-semver)
+    "4.0.9(@types/node@22.13.4)",                        // peer-annotated lockfile version (non-semver)
+    "srv-creds-dbac-dsp-dev-uks-001",                    // cloud resource id, region + zero-padded instance suffix
+    "app-web-frontend-prod-eus-002",                     // similar resource-name shape
+    "vm-db-primary-qa-weu-010");                         // similar resource-name shape
 
   static final List<String> KNOWN_NON_SECRETS = Stream.of(
     FAKE_VALUE_SAMPLES, SECRET_SAMPLES, PLACEHOLDER_SAMPLES,
@@ -197,7 +200,11 @@ class SecretClassifierTest {
     "Xk9Lm2Qp7Rs4Tv1Wz0",
     "9f8e7d6c5b4a392817",
     "Tr0ub4dor&3xpl0!t",
-    "__not_closed" // leading __ without closing __ should not match
+    "__not_closed", // leading __ without closing __ should not match
+    // Real-looking secret shapes must not be caught by the resource-identifier pattern either.
+    "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",             // 32-char hex token
+    "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo1Njc4OTA=", // base64 token
+    "6ba7b810-9dad-11d1-80b4-00c04fd430c8"          // UUID-shaped value
   })
   void shouldNotClassifyRealisticTokensAsNonSecrets(String value) {
     assertThat(SecretClassifier.isKnownNonSecret(value)).isFalse();

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
@@ -101,7 +101,6 @@ class SecretClassifierTest {
     "/var/keys/gsa-key.json",
     "v1.2.3", ">=1.0.0", "~1.4.5-alpha",                // semver variants
     "4.0.9(@types/node@22.13.4)",                        // peer-annotated lockfile version (non-semver)
-    "srv-creds-dbac-dsp-dev-uks-001",                    // cloud resource id, region + zero-padded instance suffix
     "app-web-frontend-prod-eus-002",                     // similar resource-name shape
     "vm-db-primary-qa-weu-010");                         // similar resource-name shape
 


### PR DESCRIPTION
## Why

User feedback triage surfaced a false positive on a hardcoded-secrets rule (S6418, generic YAML): a value shaped like an Azure resource-naming-convention identifier — hyphen-segmented, ending in a short region abbreviation plus a zero-padded instance number (e.g. `src-test-srv-dev-uks-001`) — was flagged because the sibling key contained a credential-related word (e.g. "...Credential").

It slipped through `SecretClassifier.isKnownNonSecret()` because the existing `STRUCTURED_FORMAT` path-pattern only recognizes `/`-separated paths, not `-`-separated identifiers, and the abbreviated, non-dictionary hyphen segments (e.g. 3-4 letter region/component codes) score as "random enough" / "not human language" just like a real secret would.

## What

Added a new pattern to the `STRUCTURED_FORMAT` category in `SecretClassifier`:

```
^[a-z][a-z0-9]*+(?:-[a-z0-9]++){2,}-[a-z]{2,4}-\d{2,4}$
```

This requires at least 5 lowercase alphanumeric hyphen-separated segments, with the value ending in a short (2-4 char) alpha segment followed by a 2-4 digit numeric suffix. This is the structural shape shared by cloud resource-naming conventions across providers — it intentionally does **not** hardcode any specific region/provider vocabulary (e.g. no list of Azure region abbreviations), since that would be unmaintainable and provider-specific.

The pattern is conservative by construction: a real high-entropy secret (base64, hex, random alphanumeric, UUID) essentially never has this many hyphen-separated segments capped by a short alpha suffix and a zero-padded numeric instance id, so the risk of suppressing genuine secrets is low.

This is `SecretClassifier`, shared across every analyzer calling `isKnownNonSecret()`, so the change was kept as narrow as possible and validated against the existing test corpus.

## Test evidence

- Added negative cases to `shouldNotClassifyRealisticTokensAsNonSecrets` proving the new pattern does **not** catch real-looking secrets: a 32-char hex token, a base64 token, and a UUID-shaped value.
- Ran the full `commons` test suite (not just the new test) — all tests pass, no existing "should still be flagged" case flipped to non-secret.

```
mvn -pl commons -am test
```
passes with no failures.