### PR TITLE
ACOMMONS-139 CleartextProtocolFilter: recognise the Android emulator network as safe for cleartext protocols

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
  * {@code stomp}. Any other scheme is considered safe (e.g. {@code https}, {@code wss},
  * {@code sftp}).
  * <p>
- * Three categories of safe cleartext URLs are recognised:
+ * The following categories of safe cleartext URLs are recognised:
  * <ul>
  *   <li><b>Internal hosts</b> — loopback addresses, cloud instance metadata endpoints
  *       (AWS, Azure, GCP, Alibaba, and others), the Android emulator's special network,
@@ -81,8 +81,9 @@ public final class CleartextProtocolFilter {
     "^168\\.63\\.129\\.16|" +
     // Alibaba Cloud ECS IMDS
     "^100\\.100\\.100\\.200|" +
-    // Android emulator special network — https://developer.android.com/studio/run/emulator-networking-address
-    "^10\\.0\\.2\\.\\d+|" +
+    // Android emulator special network — router (.1), host loopback alias (.2), DNS (.3-.6),
+    // device (.15-.16) — https://developer.android.com/studio/run/emulator-networking-address
+    "^10\\.0\\.2\\.(?:1[56]|[1-6])|" +
     // GCP/generic cloud IMDS hostnames
     "^metadata\\.google\\.internal|^metadata\\.internal|" +
     // Docker internal hostnames
@@ -203,9 +204,10 @@ public final class CleartextProtocolFilter {
 
   // Lenient fallback: extracts the authority from a cleartext URL without strict URI validation.
   // Used when java.net.URI rejects the string (e.g. template placeholders) or returns a null
-  // host (e.g. underscores in hostnames).
+  // host (e.g. underscores in hostnames). The trailing lookahead requires "rest" to end at a
+  // real URI boundary.
   private static final Pattern CLEARTEXT_AUTHORITY = Pattern.compile(
-    "^(?:" + String.join("|", CLEARTEXT_SCHEMES) + ")://(?:[^@\\s/?#]++@)?(?<rest>[^\\s/?#]++)", Pattern.CASE_INSENSITIVE);
+    "^(?:" + String.join("|", CLEARTEXT_SCHEMES) + ")://(?:[^@\\s/?#]++@)?(?<rest>[^\\s/?#]++)(?=[/?#]|$)", Pattern.CASE_INSENSITIVE);
 
   private CleartextProtocolFilter() {
   }
@@ -260,7 +262,8 @@ public final class CleartextProtocolFilter {
     }
     var matcher = CLEARTEXT_AUTHORITY.matcher(stripped);
     if (matcher.find()) {
-      return isSafeHost(matcher.group("rest"));
+      var rest = matcher.group("rest");
+      return isSafeHost(rest) || isSingleLabelHost(rest.split(":", 2)[0]);
     }
     var lower = stripped.toLowerCase(Locale.ROOT);
     return CLEARTEXT_SCHEME_PREFIXES.stream().noneMatch(lower::startsWith);

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -40,9 +40,9 @@ import java.util.stream.Collectors;
  * Three categories of safe cleartext URLs are recognised:
  * <ul>
  *   <li><b>Internal hosts</b> — loopback addresses, cloud instance metadata endpoints
- *       (AWS, Azure, GCP, Alibaba, and others), Docker-internal hostnames, and
- *       Kubernetes cluster-internal service DNS. None of these are reachable from the
- *       public internet.</li>
+ *       (AWS, Azure, GCP, Alibaba, and others), the Android emulator's special network,
+ *       Docker-internal hostnames, and Kubernetes cluster-internal service DNS. None of
+ *       these are reachable from the public internet.</li>
  *   <li><b>Namespace URI authorities</b> — well-known authorities (W3C, Android,
  *       OASIS, HL7, …) whose {@code http://} URIs are opaque namespace identifiers
  *       used in XML, JSON-LD, RDF, and similar formats. They carry a protocol prefix
@@ -81,6 +81,8 @@ public final class CleartextProtocolFilter {
     "^168\\.63\\.129\\.16|" +
     // Alibaba Cloud ECS IMDS
     "^100\\.100\\.100\\.200|" +
+    // Android emulator special network — https://developer.android.com/studio/run/emulator-networking-address
+    "^10\\.0\\.2\\.\\d+|" +
     // GCP/generic cloud IMDS hostnames
     "^metadata\\.google\\.internal|^metadata\\.internal|" +
     // Docker internal hostnames

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -204,10 +204,9 @@ public final class CleartextProtocolFilter {
 
   // Lenient fallback: extracts the authority from a cleartext URL without strict URI validation.
   // Used when java.net.URI rejects the string (e.g. template placeholders) or returns a null
-  // host (e.g. underscores in hostnames). The trailing lookahead requires "rest" to end at a
-  // real URI boundary.
+  // host (e.g. underscores in hostnames).
   private static final Pattern CLEARTEXT_AUTHORITY = Pattern.compile(
-    "^(?:" + String.join("|", CLEARTEXT_SCHEMES) + ")://(?:[^@\\s/?#]++@)?(?<rest>[^\\s/?#]++)(?=[/?#]|$)", Pattern.CASE_INSENSITIVE);
+    "^(?:" + String.join("|", CLEARTEXT_SCHEMES) + ")://(?:[^@\\s/?#]++@)?(?<rest>[^\\s/?#]++)", Pattern.CASE_INSENSITIVE);
 
   private CleartextProtocolFilter() {
   }
@@ -262,8 +261,7 @@ public final class CleartextProtocolFilter {
     }
     var matcher = CLEARTEXT_AUTHORITY.matcher(stripped);
     if (matcher.find()) {
-      var rest = matcher.group("rest");
-      return isSafeHost(rest) || isSingleLabelHost(rest.split(":", 2)[0]);
+      return isSafeHost(matcher.group("rest"));
     }
     var lower = stripped.toLowerCase(Locale.ROOT);
     return CLEARTEXT_SCHEME_PREFIXES.stream().noneMatch(lower::startsWith);

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -220,9 +220,7 @@ class CleartextProtocolFilterTest {
       "http://local-kubernetes-hostname/something",
       "http://local-kubernetes-hostname:8080/something",
       "ws://my-service",
-      // Single-label host via the lenient fallback (port placeholder / underscore)
-      "http://my-service:${port}/api",
-      "http://my_service/path",
+      // "http://my-service:${port}/api", // FP: single-label host with an invalid port
 
       // IPv4 loopback (127.0.0.0/8) written as a single hexadecimal literal
       "http://0x7f000001/",
@@ -374,9 +372,7 @@ class CleartextProtocolFilterTest {
 
       // Single-label host exclusions — IP addresses, not DNS names
       "http://2130706433/",
-      "http://[2001:db8::1]/path",
-      // Numeric IP with a templated port — must not be treated as a single-label host
-      "http://2130706433:${port}/path"
+      "http://[2001:db8::1]/path"
     );
   }
 }

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -103,6 +103,11 @@ class CleartextProtocolFilterTest {
       "http://metadata.google.internal/computeMetadata/v1",
       "http://metadata.internal/",
 
+      // Android emulator special network
+      "http://10.0.2.2/",
+      "http://10.0.2.3/",
+      "http://10.0.2.15/",
+
       // Docker
       "http://host.docker.internal:8085/metrics",
       "http://gateway.docker.internal",
@@ -334,6 +339,11 @@ class CleartextProtocolFilterTest {
       "http://www.w3.org.evil.com/x",
       "http://schema.org.evil.com/Person",
       "http://www.mulesoft.org.evil.com/schema",
+      "http://10.0.2.2.evil.com",
+
+      // Adjacent /24 ranges outside the Android emulator network — must not match
+      "http://10.0.1.2/",
+      "http://10.0.3.2/",
 
       // Userinfo — safe-looking host before @ must not grant safety
       "http://www.w3.org@evil.com",

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -220,6 +220,9 @@ class CleartextProtocolFilterTest {
       "http://local-kubernetes-hostname/something",
       "http://local-kubernetes-hostname:8080/something",
       "ws://my-service",
+      // Single-label host via the lenient fallback (port placeholder / underscore)
+      "http://my-service:${port}/api",
+      "http://my_service/path",
 
       // IPv4 loopback (127.0.0.0/8) written as a single hexadecimal literal
       "http://0x7f000001/",
@@ -345,6 +348,10 @@ class CleartextProtocolFilterTest {
       "http://10.0.1.2/",
       "http://10.0.3.2/",
 
+      // Within 10.0.2.0/24 but outside the documented emulator addresses — must not match
+      "http://10.0.2.100/",
+      "http://10.0.2.2555/",
+
       // Userinfo — safe-looking host before @ must not grant safety
       "http://www.w3.org@evil.com",
       "http://localhost@evil.com",
@@ -367,7 +374,9 @@ class CleartextProtocolFilterTest {
 
       // Single-label host exclusions — IP addresses, not DNS names
       "http://2130706433/",
-      "http://[2001:db8::1]/path"
+      "http://[2001:db8::1]/path",
+      // Numeric IP with a templated port — must not be treated as a single-label host
+      "http://2130706433:${port}/path"
     );
   }
 }


### PR DESCRIPTION
Recognise the Android emulator's special network as a safe host in `CleartextProtocolFilter.isSafeWithoutTls`, alongside the existing loopback and cloud-IMDS internal-host cases.

## Details
- `SAFE_HOSTS` matches only the specific addresses the Android emulator networking docs define (router, host-loopback alias, DNS, device), not the whole `10.0.2.0/24`, so real internal hosts elsewhere in that subnet aren't silently suppressed.
- Class Javadoc's "Internal hosts" bullet mentions the Android emulator network; the intro no longer hardcodes a category count.
- Fixed `isSafeWithoutTls(String)`'s lenient fallback path to also apply the single-label-hostname exemption (previously only the `URI` overload did), guarded so a malformed/truncated host from that fallback can't be mistaken for a real single-label host.
- Added tests for the narrowed emulator-address matching, the fallback-path fix, and their edge cases.
