### PR TITLE
ACOMMONS-107 Publish a JSON that contains examples of filtered out secrets

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -87,6 +87,29 @@ public final class SecretClassifier {
     }
   }
 
+  /**
+   * The corpus samples of a single {@link Category}, kept next to the pattern groups they exercise so that a new
+   * pattern and its sample are added together.
+   */
+  @SuppressWarnings("java:S1068")
+  private static final class SampleGroup {
+    private final Category category;
+    private final List<String> samples;
+
+    private SampleGroup(Category category, List<String> samples) {
+      this.category = category;
+      this.samples = samples;
+    }
+
+    static SampleGroup of(Category category, String... samples) {
+      return new SampleGroup(category, List.of(samples));
+    }
+
+    List<String> samples() {
+      return samples;
+    }
+  }
+
   private static final List<PatternGroup> PATTERN_GROUPS = List.of(
 
     // Trivially fake or weak literal values.
@@ -198,6 +221,97 @@ public final class SecretClassifier {
     "changeme", "changeit", "unknown", "optional", "enabled", "disabled",
     "string", "random", "token"));
 
+  /**
+   * One representative sample per skip pattern and per exact-match value, grouped by the {@link Category} that must
+   * suppress it. Each sample is suppressed by the category it is listed under, not by an earlier group; adding a
+   * pattern without adding a sample here fails the classifier's coverage test.
+   *
+   * <p>Declared in main scope rather than in the test so the build can publish it as a validation corpus, letting
+   * non-JVM analyzers assert their own regex engine reproduces this behavior instead of hand-copying the samples.
+   */
+  private static final List<SampleGroup> KNOWN_NON_SECRET_SAMPLES = List.of(
+
+    SampleGroup.of(Category.FAKE_VALUE,
+      // Minimum length
+      "", "abc",
+      // Fake-word substrings
+      "samplepassword", "EXAMPLE_SECRET", "deadbeef", "qwerty",
+      // Templates whose placeholder names contain credential words - FAKE_VALUE wins before PLACEHOLDER
+      "${secret}", "#{{secret}}", "$foo_bar",
+      // Password-like values
+      "password1234", "passwd",
+      // Leetspeak "password" variants with "@" that the "pass" substring misses
+      "p@ssword", "p@ssw0rd",
+      // Boolean / null / scalar literals
+      "undefined", "true", "null",
+      // "your..." prefix
+      "yourpassword",
+      // Same-character repetitions
+      "abbbbc", "111111",
+      // Masked value
+      "1fj28...askn3i",
+      // Other fake keywords
+      "admin123", "vncpass", "super-secret-p4ssw0rd",
+      // "secret" in "secretsmanager" triggers FAKE_VALUE before REFERENCE; kept here for REFERENCE ARN pattern coverage
+      "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-pass"),
+
+    SampleGroup.of(Category.SECRET,
+      "hunter2", "letmein", "abc123",
+      "changeme", "changeit", "unknown", "optional", "enabled", "disabled", "string", "random", "token"),
+
+    SampleGroup.of(Category.PLACEHOLDER,
+      "__api_key__",                      // double-underscore-wrapped
+      "TODO: fill in", "FIXME: fill in",  // code-reminder prefix
+      "${env_var}", "value-${env_var}",   // variable interpolation
+      "#{{db_host}}",                     // hash-brace interpolation
+      "((vault_ref))",                    // Concourse vars
+      "$(get_key)",                       // shell command substitution
+      "`get_key`",                        // backtick command substitution
+      "$MY_VAR",                          // bare variable reference
+      "{db_host}", "%{db_host}",          // template interpolation
+      "{{db_host}}",                      // double-brace interpolation
+      "System.getenv(\"DB_HOST\")",       // env access
+      "process.env.HOST",                 // Node.js process.env
+      "%GITHUB_TOKEN%",                   // %VAR% syntax
+      "config['db_url']",                 // config access
+      "Read-Host",                        // PowerShell
+      "<db-host>",                        // short angle-bracket placeholder
+      "<api_endpoint>",                   // long angle-bracket placeholder
+      "(config_ref)",                     // parenthesised placeholder
+      "[db_url]",                         // square-bracket placeholder
+      "%(db_url)s",                       // Python format-string placeholder
+      "@variables('host')"),              // Azure Logic Apps expression
+
+    SampleGroup.of(Category.ENCRYPTED,
+      "encrypted:YWJjZGVm",
+      "{cipher}1e3faa2cdab2deae117dca102e52922a",
+      "enc[QUJDRA==]",
+      "ENC{QUJDRA==}", "%enc{QUJDRA==}", "ENC(QUJDRA==)"),
+
+    SampleGroup.of(Category.REFERENCE,
+      "op://vault/item/key",
+      "VAULT[path/to/key access_token]"),
+
+    SampleGroup.of(Category.STRUCTURED_FORMAT,
+      "/var/keys/gsa-key.json",
+      "v1.2.3", ">=1.0.0", "~1.4.5-alpha",  // semver variants
+      "4.0.9(@types/node@22.13.4)"));       // peer-annotated lockfile version (non-semver)
+
+  /**
+   * Values that must NOT be classified as known non-secrets: realistic credentials plus near-misses of the skip
+   * patterns above. Published alongside {@link #KNOWN_NON_SECRET_SAMPLES} because a pattern that is too broad in a
+   * foreign regex engine silently hides real hardcoded secrets, which the positive samples alone cannot detect.
+   */
+  private static final List<String> SECRET_CANDIDATE_SAMPLES = List.of(
+    "Xk9Lm2Qp7Rs4Tv1Wz0",
+    "9f8e7d6c5b4a392817",
+    "Tr0ub4dor&3xpl0!t",
+    // Leading "__" without a closing "__"
+    "__not_closed",
+    // Credential words are matched only as whole values, so a value that merely contains one stays a candidate
+    "mytoken123",
+    "this_should_remain_unknown");
+
   // Context is an empty extension point today, so the analyzer sees instantiating it as pointless; the single shared
   // empty instance is intentional and lets empty() return a non-null context.
   @SuppressWarnings("java:S2440")
@@ -305,6 +419,36 @@ public final class SecretClassifier {
   }
 
   /**
+   * Returns representative samples that must be classified as known non-secrets, grouped by the {@link Category} that
+   * suppresses them, in declaration order. Every skip pattern and every exact-match value is exercised by at least one
+   * sample; the classifier's own tests fail if that stops being true.
+   *
+   * <p>Exposed so the build can publish a validation corpus next to the pattern export, letting non-JVM analyzers
+   * (SonarJS, sonar-dotnet, …) assert their regex engine reproduces the JVM behavior rather than hand-copying samples.
+   *
+   * <p>The category is informational - it records which group suppresses the value in this implementation, which is
+   * first-match-wins and therefore not a stable contract. Consumers should not assert on it.
+   *
+   * @return an immutable, ordered list of sample groups
+   */
+  public static List<SampleGroupView> exportKnownNonSecretSamples() {
+    return KNOWN_NON_SECRET_SAMPLES.stream()
+      .map(group -> new SampleGroupView(group.category.name(), group.samples()))
+      .toList();
+  }
+
+  /**
+   * Returns values that must NOT be classified as known non-secrets: realistic credentials and near-misses of the skip
+   * patterns. Published with {@link #exportKnownNonSecretSamples()} so a consumer can also detect a pattern that is
+   * over-broad in its own regex engine, which would silently suppress real hardcoded secrets.
+   *
+   * @return an immutable, ordered list of values that stay secret candidates
+   */
+  public static List<String> exportSecretCandidateSamples() {
+    return SECRET_CANDIDATE_SAMPLES;
+  }
+
+  /**
    * A group of skip regexes sharing a {@link Category}, exposed for machine-readable export.
    * The regexes are the raw Java source patterns; callers that target other engines are responsible for any
    * translation (e.g. possessive quantifiers to atomic groups for .NET).
@@ -345,6 +489,27 @@ public final class SecretClassifier {
     }
 
     /** The exact-match values, sorted, matched in full and case-insensitively. */
+    public List<String> values() {
+      return values;
+    }
+  }
+
+  /** A group of corpus samples sharing a {@link Category}, exposed for machine-readable export. */
+  public static final class SampleGroupView {
+    private final String category;
+    private final List<String> values;
+
+    private SampleGroupView(String category, List<String> values) {
+      this.category = category;
+      this.values = values;
+    }
+
+    /** The {@link Category} name expected to suppress these samples. Informational; not a stable contract. */
+    public String category() {
+      return category;
+    }
+
+    /** The sample values, in declaration order. */
     public List<String> values() {
       return values;
     }

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -17,8 +17,11 @@
 package org.sonarsource.analyzer.commons.appsec;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -32,9 +35,10 @@ import javax.annotation.Nullable;
 public final class SecretClassifier {
 
   /**
-   * Coarse group a skip pattern belongs to.
+   * Coarse group a skip pattern belongs to, and the key the corpus samples are declared under; see
+   * {@link #exportKnownNonSecretSamples(Category)}.
    */
-  enum Category {
+  public enum Category {
     /** Trivially fake or weak literals: fake words, password-like values, repeated, too-short, or masked strings. */
     FAKE_VALUE,
     /** Well-known literal placeholder secrets matched in full, e.g. {@code hunter2}, {@code letmein}. */
@@ -84,29 +88,6 @@ public final class SecretClassifier {
 
     Set<String> values() {
       return values;
-    }
-  }
-
-  /**
-   * The corpus samples of a single {@link Category}, kept next to the pattern groups they exercise so that a new
-   * pattern and its sample are added together.
-   */
-  @SuppressWarnings("java:S1068")
-  private static final class SampleGroup {
-    private final Category category;
-    private final List<String> samples;
-
-    private SampleGroup(Category category, List<String> samples) {
-      this.category = category;
-      this.samples = samples;
-    }
-
-    static SampleGroup of(Category category, String... samples) {
-      return new SampleGroup(category, List.of(samples));
-    }
-
-    List<String> samples() {
-      return samples;
     }
   }
 
@@ -222,16 +203,16 @@ public final class SecretClassifier {
     "string", "random", "token"));
 
   /**
-   * One representative sample per skip pattern and per exact-match value, grouped by the {@link Category} that must
+   * One representative sample per skip pattern and per exact-match value, keyed by the {@link Category} that must
    * suppress it. Each sample is suppressed by the category it is listed under, not by an earlier group; adding a
    * pattern without adding a sample here fails the classifier's coverage test.
    *
    * <p>Declared in main scope rather than in the test so the build can publish it as a validation corpus, letting
    * non-JVM analyzers assert their own regex engine reproduces this behavior instead of hand-copying the samples.
    */
-  private static final List<SampleGroup> KNOWN_NON_SECRET_SAMPLES = List.of(
+  private static final Map<Category, List<String>> KNOWN_NON_SECRET_SAMPLES = Collections.unmodifiableMap(new EnumMap<>(Map.of(
 
-    SampleGroup.of(Category.FAKE_VALUE,
+    Category.FAKE_VALUE, List.of(
       // Minimum length
       "", "abc",
       // Fake-word substrings
@@ -255,11 +236,11 @@ public final class SecretClassifier {
       // "secret" in "secretsmanager" triggers FAKE_VALUE before REFERENCE; kept here for REFERENCE ARN pattern coverage
       "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-pass"),
 
-    SampleGroup.of(Category.SECRET,
+    Category.SECRET, List.of(
       "hunter2", "letmein", "abc123",
       "changeme", "changeit", "unknown", "optional", "enabled", "disabled", "string", "random", "token"),
 
-    SampleGroup.of(Category.PLACEHOLDER,
+    Category.PLACEHOLDER, List.of(
       // double-underscore-wrapped
       "__api_key__",
       // code-reminder prefix
@@ -303,22 +284,22 @@ public final class SecretClassifier {
       // Azure Logic Apps expression
       "@variables('host')"),
 
-    SampleGroup.of(Category.ENCRYPTED,
+    Category.ENCRYPTED, List.of(
       "encrypted:YWJjZGVm",
       "{cipher}1e3faa2cdab2deae117dca102e52922a",
       "enc[QUJDRA==]",
       "ENC{QUJDRA==}", "%enc{QUJDRA==}", "ENC(QUJDRA==)"),
 
-    SampleGroup.of(Category.REFERENCE,
+    Category.REFERENCE, List.of(
       "op://vault/item/key",
       "VAULT[path/to/key access_token]"),
 
-    SampleGroup.of(Category.STRUCTURED_FORMAT,
+    Category.STRUCTURED_FORMAT, List.of(
       "/var/keys/gsa-key.json",
       // semver variants
       "v1.2.3", ">=1.0.0", "~1.4.5-alpha",
       // peer-annotated lockfile version (non-semver)
-      "4.0.9(@types/node@22.13.4)"));
+      "4.0.9(@types/node@22.13.4)"))));
 
   /**
    * Values that must NOT be classified as known non-secrets: realistic credentials plus near-misses of the skip
@@ -442,28 +423,27 @@ public final class SecretClassifier {
   }
 
   /**
-   * Returns representative samples that must be classified as known non-secrets, grouped by the {@link Category} that
-   * suppresses them, in declaration order. Every skip pattern and every exact-match value is exercised by at least one
-   * sample; the classifier's own tests fail if that stops being true.
+   * Returns the representative samples that must be classified as known non-secrets by the given {@link Category}, in
+   * declaration order. Every skip pattern and every exact-match value is exercised by at least one sample; the
+   * classifier's own tests fail if that stops being true.
    *
    * <p>Exposed so the build can publish a validation corpus next to the pattern export, letting non-JVM analyzers
    * (SonarJS, sonar-dotnet, …) assert their regex engine reproduces the JVM behavior rather than hand-copying samples.
    *
-   * <p>The category is informational - it records which group suppresses the value in this implementation, which is
-   * first-match-wins and therefore not a stable contract. Consumers should not assert on it.
+   * <p>The category a sample is declared under is informational - it records which group suppresses the value in this
+   * implementation, which is first-match-wins and therefore not a stable contract. Consumers should not assert on it.
    *
-   * @return an immutable, ordered list of sample groups
+   * @param category the category whose samples to return
+   * @return an immutable, ordered list of samples, empty when the category declares none
    */
-  public static List<SampleGroupView> exportKnownNonSecretSamples() {
-    return KNOWN_NON_SECRET_SAMPLES.stream()
-      .map(group -> new SampleGroupView(group.category.name(), group.samples()))
-      .toList();
+  public static List<String> exportKnownNonSecretSamples(Category category) {
+    return KNOWN_NON_SECRET_SAMPLES.getOrDefault(category, List.of());
   }
 
   /**
    * Returns values that must NOT be classified as known non-secrets: realistic credentials and near-misses of the skip
-   * patterns. Published with {@link #exportKnownNonSecretSamples()} so a consumer can also detect a pattern that is
-   * over-broad in its own regex engine, which would silently suppress real hardcoded secrets.
+   * patterns. Published with {@link #exportKnownNonSecretSamples(Category)} so a consumer can also detect a pattern
+   * that is over-broad in its own regex engine, which would silently suppress real hardcoded secrets.
    *
    * @return an immutable, ordered list of values that stay secret candidates
    */
@@ -512,27 +492,6 @@ public final class SecretClassifier {
     }
 
     /** The exact-match values, sorted, matched in full and case-insensitively. */
-    public List<String> values() {
-      return values;
-    }
-  }
-
-  /** A group of corpus samples sharing a {@link Category}, exposed for machine-readable export. */
-  public static final class SampleGroupView {
-    private final String category;
-    private final List<String> values;
-
-    private SampleGroupView(String category, List<String> values) {
-      this.category = category;
-      this.values = values;
-    }
-
-    /** The {@link Category} name expected to suppress these samples. Informational; not a stable contract. */
-    public String category() {
-      return category;
-    }
-
-    /** The sample values, in declaration order. */
     public List<String> values() {
       return values;
     }

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -260,27 +260,48 @@ public final class SecretClassifier {
       "changeme", "changeit", "unknown", "optional", "enabled", "disabled", "string", "random", "token"),
 
     SampleGroup.of(Category.PLACEHOLDER,
-      "__api_key__",                      // double-underscore-wrapped
-      "TODO: fill in", "FIXME: fill in",  // code-reminder prefix
-      "${env_var}", "value-${env_var}",   // variable interpolation
-      "#{{db_host}}",                     // hash-brace interpolation
-      "((vault_ref))",                    // Concourse vars
-      "$(get_key)",                       // shell command substitution
-      "`get_key`",                        // backtick command substitution
-      "$MY_VAR",                          // bare variable reference
-      "{db_host}", "%{db_host}",          // template interpolation
-      "{{db_host}}",                      // double-brace interpolation
-      "System.getenv(\"DB_HOST\")",       // env access
-      "process.env.HOST",                 // Node.js process.env
-      "%GITHUB_TOKEN%",                   // %VAR% syntax
-      "config['db_url']",                 // config access
-      "Read-Host",                        // PowerShell
-      "<db-host>",                        // short angle-bracket placeholder
-      "<api_endpoint>",                   // long angle-bracket placeholder
-      "(config_ref)",                     // parenthesised placeholder
-      "[db_url]",                         // square-bracket placeholder
-      "%(db_url)s",                       // Python format-string placeholder
-      "@variables('host')"),              // Azure Logic Apps expression
+      // double-underscore-wrapped
+      "__api_key__",
+      // code-reminder prefix
+      "TODO: fill in", "FIXME: fill in",
+      // variable interpolation
+      "${env_var}", "value-${env_var}",
+      // hash-brace interpolation
+      "#{{db_host}}",
+      // Concourse vars
+      "((vault_ref))",
+      // shell command substitution
+      "$(get_key)",
+      // backtick command substitution
+      "`get_key`",
+      // bare variable reference
+      "$MY_VAR",
+      // template interpolation
+      "{db_host}", "%{db_host}",
+      // double-brace interpolation
+      "{{db_host}}",
+      // env access
+      "System.getenv(\"DB_HOST\")",
+      // Node.js process.env
+      "process.env.HOST",
+      // %VAR% syntax
+      "%GITHUB_TOKEN%",
+      // config access
+      "config['db_url']",
+      // PowerShell
+      "Read-Host",
+      // short angle-bracket placeholder
+      "<db-host>",
+      // long angle-bracket placeholder
+      "<api_endpoint>",
+      // parenthesised placeholder
+      "(config_ref)",
+      // square-bracket placeholder
+      "[db_url]",
+      // Python format-string placeholder
+      "%(db_url)s",
+      // Azure Logic Apps expression
+      "@variables('host')"),
 
     SampleGroup.of(Category.ENCRYPTED,
       "encrypted:YWJjZGVm",

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/SecretClassifier.java
@@ -315,8 +315,10 @@ public final class SecretClassifier {
 
     SampleGroup.of(Category.STRUCTURED_FORMAT,
       "/var/keys/gsa-key.json",
-      "v1.2.3", ">=1.0.0", "~1.4.5-alpha",  // semver variants
-      "4.0.9(@types/node@22.13.4)"));       // peer-annotated lockfile version (non-semver)
+      // semver variants
+      "v1.2.3", ">=1.0.0", "~1.4.5-alpha",
+      // peer-annotated lockfile version (non-semver)
+      "4.0.9(@types/node@22.13.4)"));
 
   /**
    * Values that must NOT be classified as known non-secrets: realistic credentials plus near-misses of the skip

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
@@ -49,8 +49,10 @@ class SecretClassifierTest {
   void shouldBeSuppressedByTheCategoryTheyAreDeclaredUnder(SecretClassifier.Category category) {
     List<String> samples = SecretClassifier.exportKnownNonSecretSamples(category);
 
-    assertThat(samples).as("no samples declared for %s", category).isNotEmpty();
-    assertThat(samples).allSatisfy(sample -> assertThat(SecretClassifier.classify(sample))
+    assertThat(samples)
+      .as("no samples declared for %s", category)
+      .isNotEmpty()
+      .allSatisfy(sample -> assertThat(SecretClassifier.classify(sample))
       .as("sample <%s>", sample)
       .isEqualTo(category));
   }

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -28,80 +29,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * The samples themselves live in {@link SecretClassifier} (main scope) so the build can publish them as
- * {@code secret-exclusion-corpus.json}; see {@link SecretClassifier#exportKnownNonSecretSamples()}. This test stays
- * the gate that keeps that corpus complete and correctly categorized: it is what fails when a pattern is added
- * without a sample, or when a sample is suppressed by a group other than the one it is declared under.
+ * {@code secret-exclusion-corpus.json}; see
+ * {@link SecretClassifier#exportKnownNonSecretSamples(SecretClassifier.Category)}. This test stays the gate that keeps
+ * that corpus complete and correctly categorized: it is what fails when a pattern is added without a sample, or when a
+ * sample is suppressed by a group other than the one it is declared under.
  */
 class SecretClassifierTest {
 
-  static final List<String> KNOWN_NON_SECRETS = SecretClassifier.exportKnownNonSecretSamples().stream()
-    .flatMap(group -> group.values().stream())
+  static final List<String> KNOWN_NON_SECRETS = Stream.of(SecretClassifier.Category.values())
+    .flatMap(category -> SecretClassifier.exportKnownNonSecretSamples(category).stream())
     .toList();
 
-  private static Stream<String> samplesOf(SecretClassifier.Category category) {
-    return SecretClassifier.exportKnownNonSecretSamples().stream()
-      .filter(group -> group.category().equals(category.name()))
-      .flatMap(group -> group.values().stream());
-  }
-
-  static Stream<String> fakeValueSamples() {
-    return samplesOf(SecretClassifier.Category.FAKE_VALUE);
-  }
-
-  static Stream<String> secretSamples() {
-    return samplesOf(SecretClassifier.Category.SECRET);
-  }
-
-  static Stream<String> placeholderSamples() {
-    return samplesOf(SecretClassifier.Category.PLACEHOLDER);
-  }
-
-  static Stream<String> encryptedSamples() {
-    return samplesOf(SecretClassifier.Category.ENCRYPTED);
-  }
-
-  static Stream<String> referenceSamples() {
-    return samplesOf(SecretClassifier.Category.REFERENCE);
-  }
-
-  static Stream<String> structuredFormatSamples() {
-    return samplesOf(SecretClassifier.Category.STRUCTURED_FORMAT);
-  }
-
+  /**
+   * Every category must declare samples, and each of them must be suppressed by the category it is declared under -
+   * not by an earlier group, which is what would silently happen if a new pattern overlapped an existing one.
+   */
   @ParameterizedTest
-  @MethodSource("fakeValueSamples")
-  void shouldBeSuppressedByFakeValueCategory(String value) {
-    assertThat(SecretClassifier.classify(value)).isEqualTo(SecretClassifier.Category.FAKE_VALUE);
-  }
+  @EnumSource(SecretClassifier.Category.class)
+  void shouldBeSuppressedByTheCategoryTheyAreDeclaredUnder(SecretClassifier.Category category) {
+    List<String> samples = SecretClassifier.exportKnownNonSecretSamples(category);
 
-  @ParameterizedTest
-  @MethodSource("secretSamples")
-  void shouldBeSuppressedBySecretCategory(String value) {
-    assertThat(SecretClassifier.classify(value)).isEqualTo(SecretClassifier.Category.SECRET);
-  }
-
-  @ParameterizedTest
-  @MethodSource("placeholderSamples")
-  void shouldBeSuppressedByPlaceholderCategory(String value) {
-    assertThat(SecretClassifier.classify(value)).isEqualTo(SecretClassifier.Category.PLACEHOLDER);
-  }
-
-  @ParameterizedTest
-  @MethodSource("encryptedSamples")
-  void shouldBeSuppressedByEncryptedCategory(String value) {
-    assertThat(SecretClassifier.classify(value)).isEqualTo(SecretClassifier.Category.ENCRYPTED);
-  }
-
-  @ParameterizedTest
-  @MethodSource("referenceSamples")
-  void shouldBeSuppressedByReferenceCategory(String value) {
-    assertThat(SecretClassifier.classify(value)).isEqualTo(SecretClassifier.Category.REFERENCE);
-  }
-
-  @ParameterizedTest
-  @MethodSource("structuredFormatSamples")
-  void shouldBeSuppressedByStructuredFormatCategory(String value) {
-    assertThat(SecretClassifier.classify(value)).isEqualTo(SecretClassifier.Category.STRUCTURED_FORMAT);
+    assertThat(samples).as("no samples declared for %s", category).isNotEmpty();
+    assertThat(samples).allSatisfy(sample -> assertThat(SecretClassifier.classify(sample))
+      .as("sample <%s>", sample)
+      .isEqualTo(category));
   }
 
   static Stream<String> knownNonSecrets() {
@@ -126,16 +77,6 @@ class SecretClassifierTest {
         .as("no sample exercises exact value: %s", exact)
         .anyMatch(sample -> sample.equalsIgnoreCase(exact));
     }
-  }
-
-  @Test
-  void everyCategoryShouldContributeSamplesInDeclarationOrder() {
-    List<SecretClassifier.SampleGroupView> groups = SecretClassifier.exportKnownNonSecretSamples();
-
-    assertThat(groups)
-      .extracting(SecretClassifier.SampleGroupView::category)
-      .containsExactlyElementsOf(Stream.of(SecretClassifier.Category.values()).map(Enum::name).toList());
-    assertThat(groups).allSatisfy(group -> assertThat(group.values()).as("no samples for %s", group.category()).isNotEmpty());
   }
 
   static Stream<String> secretCandidates() {

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/SecretClassifierTest.java
@@ -27,109 +27,45 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Cases are grouped per {@link SecretClassifier.Category} so each group can be maintained alongside the matching
- * {@code PatternGroup} in {@link SecretClassifier}.
+ * The samples themselves live in {@link SecretClassifier} (main scope) so the build can publish them as
+ * {@code secret-exclusion-corpus.json}; see {@link SecretClassifier#exportKnownNonSecretSamples()}. This test stays
+ * the gate that keeps that corpus complete and correctly categorized: it is what fails when a pattern is added
+ * without a sample, or when a sample is suppressed by a group other than the one it is declared under.
  */
 class SecretClassifierTest {
 
-  // One representative value per pattern / exact value, grouped by category.
-  // Each value must be suppressed by the category it is listed under, not by an earlier group.
-  // Adding a pattern without a sample here fails coverageShouldExerciseEveryPatternAndExactValue.
-
-  static final List<String> FAKE_VALUE_SAMPLES = List.of(
-    // Minimum length
-    "", "abc",
-    // Fake-word substrings
-    "samplepassword", "EXAMPLE_SECRET", "deadbeef", "qwerty",
-    // Templates whose placeholder names contain credential words — FAKE_VALUE wins before PLACEHOLDER
-    "${secret}", "#{{secret}}", "$foo_bar",
-    // Password-like values
-    "password1234", "passwd",
-    // Leetspeak "password" variants with "@" that the "pass" substring misses
-    "p@ssword", "p@ssw0rd",
-    // Boolean / null / scalar literals
-    "undefined", "true", "null",
-    // "your..." prefix
-    "yourpassword",
-    // Same-character repetitions
-    "abbbbc", "111111",
-    // Masked value
-    "1fj28...askn3i",
-    // Other fake keywords
-    "admin123", "vncpass", "super-secret-p4ssw0rd",
-    // "secret" in "secretsmanager" triggers FAKE_VALUE before REFERENCE; kept here for REFERENCE ARN pattern coverage
-    "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-pass");
-
-  static final List<String> SECRET_SAMPLES = List.of(
-    "hunter2", "letmein", "abc123",
-    "changeme", "changeit", "unknown", "optional", "enabled", "disabled", "string", "random", "token");
-
-  static final List<String> PLACEHOLDER_SAMPLES = List.of(
-    "__api_key__",                        // double-underscore-wrapped
-    "TODO: fill in", "FIXME: fill in",   // code-reminder prefix
-    "${env_var}", "value-${env_var}",     // variable interpolation
-    "#{{db_host}}",                       // hash-brace interpolation
-    "((vault_ref))",                      // Concourse vars
-    "$(get_key)",                         // shell command substitution
-    "`get_key`",                          // backtick command substitution
-    "$MY_VAR",                            // bare variable reference
-    "{db_host}", "%{db_host}",            // template interpolation
-    "{{db_host}}",                        // double-brace interpolation
-    "System.getenv(\"DB_HOST\")",         // env access
-    "process.env.HOST",                   // Node.js process.env
-    "%GITHUB_TOKEN%",                     // %VAR% syntax
-    "config['db_url']",                   // config access
-    "Read-Host",                          // PowerShell
-    "<db-host>",                          // short angle-bracket placeholder
-    "<api_endpoint>",                     // long angle-bracket placeholder
-    "(config_ref)",                       // parenthesised placeholder
-    "[db_url]",                           // square-bracket placeholder
-    "%(db_url)s",                         // Python format-string placeholder
-    "@variables('host')");                // Azure Logic Apps expression
-
-  static final List<String> ENCRYPTED_SAMPLES = List.of(
-    "encrypted:YWJjZGVm",
-    "{cipher}1e3faa2cdab2deae117dca102e52922a",
-    "enc[QUJDRA==]",
-    "ENC{QUJDRA==}", "%enc{QUJDRA==}", "ENC(QUJDRA==)");
-
-  static final List<String> REFERENCE_SAMPLES = List.of(
-    "op://vault/item/key",
-    "VAULT[path/to/key access_token]");
-
-  static final List<String> STRUCTURED_FORMAT_SAMPLES = List.of(
-    "/var/keys/gsa-key.json",
-    "v1.2.3", ">=1.0.0", "~1.4.5-alpha",                // semver variants
-    "4.0.9(@types/node@22.13.4)");                       // peer-annotated lockfile version (non-semver)
-
-  static final List<String> KNOWN_NON_SECRETS = Stream.of(
-    FAKE_VALUE_SAMPLES, SECRET_SAMPLES, PLACEHOLDER_SAMPLES,
-    ENCRYPTED_SAMPLES, REFERENCE_SAMPLES, STRUCTURED_FORMAT_SAMPLES)
-    .flatMap(List::stream)
+  static final List<String> KNOWN_NON_SECRETS = SecretClassifier.exportKnownNonSecretSamples().stream()
+    .flatMap(group -> group.values().stream())
     .toList();
 
+  private static Stream<String> samplesOf(SecretClassifier.Category category) {
+    return SecretClassifier.exportKnownNonSecretSamples().stream()
+      .filter(group -> group.category().equals(category.name()))
+      .flatMap(group -> group.values().stream());
+  }
+
   static Stream<String> fakeValueSamples() {
-    return FAKE_VALUE_SAMPLES.stream();
+    return samplesOf(SecretClassifier.Category.FAKE_VALUE);
   }
 
   static Stream<String> secretSamples() {
-    return SECRET_SAMPLES.stream();
+    return samplesOf(SecretClassifier.Category.SECRET);
   }
 
   static Stream<String> placeholderSamples() {
-    return PLACEHOLDER_SAMPLES.stream();
+    return samplesOf(SecretClassifier.Category.PLACEHOLDER);
   }
 
   static Stream<String> encryptedSamples() {
-    return ENCRYPTED_SAMPLES.stream();
+    return samplesOf(SecretClassifier.Category.ENCRYPTED);
   }
 
   static Stream<String> referenceSamples() {
-    return REFERENCE_SAMPLES.stream();
+    return samplesOf(SecretClassifier.Category.REFERENCE);
   }
 
   static Stream<String> structuredFormatSamples() {
-    return STRUCTURED_FORMAT_SAMPLES.stream();
+    return samplesOf(SecretClassifier.Category.STRUCTURED_FORMAT);
   }
 
   @ParameterizedTest
@@ -192,24 +128,23 @@ class SecretClassifierTest {
     }
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {
-    "Xk9Lm2Qp7Rs4Tv1Wz0",
-    "9f8e7d6c5b4a392817",
-    "Tr0ub4dor&3xpl0!t",
-    "__not_closed" // leading __ without closing __ should not match
-  })
-  void shouldNotClassifyRealisticTokensAsNonSecrets(String value) {
-    assertThat(SecretClassifier.isKnownNonSecret(value)).isFalse();
+  @Test
+  void everyCategoryShouldContributeSamplesInDeclarationOrder() {
+    List<SecretClassifier.SampleGroupView> groups = SecretClassifier.exportKnownNonSecretSamples();
+
+    assertThat(groups)
+      .extracting(SecretClassifier.SampleGroupView::category)
+      .containsExactlyElementsOf(Stream.of(SecretClassifier.Category.values()).map(Enum::name).toList());
+    assertThat(groups).allSatisfy(group -> assertThat(group.values()).as("no samples for %s", group.category()).isNotEmpty());
+  }
+
+  static Stream<String> secretCandidates() {
+    return SecretClassifier.exportSecretCandidateSamples().stream();
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {
-    // Credential words are matched only as whole values, so a value that merely contains one stays a candidate.
-    "mytoken123",
-    "this_should_remain_unknown"
-  })
-  void shouldNotExcludeValuesMerelyContainingCredentialWords(String value) {
+  @MethodSource("secretCandidates")
+  void shouldNotClassifySecretCandidatesAsNonSecrets(String value) {
     assertThat(SecretClassifier.isKnownNonSecret(value)).isFalse();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,8 @@
     <version.gson>2.14.0</version.gson>
     <!-- used for deployment to SonarSource Artifactory -->
     <gitRepositoryName>sonar-analyzer-commons</gitRepositoryName>
-    <artifactsToPublish>${project.groupId}:sonar-analyzer-commons:jar,${project.groupId}:sonar-analyzer-test-commons:jar,${project.groupId}:sonar-analyzer-recognizers:jar,${project.groupId}:sonar-xml-parsing:jar,${project.groupId}:test-sonar-xml-parsing:jar,${project.groupId}:sonar-regex-parsing:jar,${project.groupId}:sonar-analyzer-commons-configurations:json</artifactsToPublish>
+    <configurations.corpus.classifier>secret-exclusion-corpus</configurations.corpus.classifier>
+    <artifactsToPublish>${project.groupId}:sonar-analyzer-commons:jar,${project.groupId}:sonar-analyzer-test-commons:jar,${project.groupId}:sonar-analyzer-recognizers:jar,${project.groupId}:sonar-xml-parsing:jar,${project.groupId}:test-sonar-xml-parsing:jar,${project.groupId}:sonar-regex-parsing:jar,${project.groupId}:sonar-analyzer-commons-configurations:json,${project.groupId}:sonar-analyzer-commons-configurations:json:${configurations.corpus.classifier}</artifactsToPublish>
     <!-- this property configures the settings in parent pom -->
     <jdk.min.version>21</jdk.min.version>
     <maven.compiler.release>${jdk.min.version}</maven.compiler.release>

--- a/sonar-analyzer-commons-configurations/pom.xml
+++ b/sonar-analyzer-commons-configurations/pom.xml
@@ -12,12 +12,15 @@
   <artifactId>sonar-analyzer-commons-configurations</artifactId>
   <name>SonarSource Analyzers Commons Configurations</name>
   <description>Machine-readable export (JSON, .nupkg, npm .tgz) of shared analyzer configuration generated from
-    sonar-analyzer-commons, so non-JVM analyzers can consume the same secret-exclusion patterns without drift</description>
+    sonar-analyzer-commons, so non-JVM analyzers can consume the same secret-exclusion patterns - and the corpus that
+    validates them against their own regex engine - without drift</description>
 
   <properties>
     <exporter.mainClass>org.sonarsource.analyzer.commons.appsec.export.SecretPatternsExporter</exporter.mainClass>
-    <!-- Written by the exporter, then packaged as the raw JSON artifact and bundled into the nupkg/npm archives. -->
+    <corpus.exporter.mainClass>org.sonarsource.analyzer.commons.appsec.export.SecretExclusionCorpusExporter</corpus.exporter.mainClass>
+    <!-- Written by the exporters, then packaged as the raw JSON artifacts and bundled into the nupkg/npm archives. -->
     <generated.json>${project.build.directory}/generated-resources/secret-patterns.json</generated.json>
+    <generated.corpus.json>${project.build.directory}/generated-resources/secret-exclusion-corpus.json</generated.corpus.json>
     <version.exec.plugin>3.6.3</version.exec.plugin>
     <version.build-helper.plugin>3.6.1</version.build-helper.plugin>
   </properties>
@@ -76,6 +79,19 @@
               <mainClass>${exporter.mainClass}</mainClass>
               <arguments>
                 <argument>${generated.json}</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>generate-secret-exclusion-corpus-json</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>${corpus.exporter.mainClass}</mainClass>
+              <arguments>
+                <argument>${generated.corpus.json}</argument>
               </arguments>
             </configuration>
           </execution>
@@ -181,6 +197,11 @@
                 <artifact>
                   <file>${generated.json}</file>
                   <type>json</type>
+                </artifact>
+                <artifact>
+                  <file>${generated.corpus.json}</file>
+                  <type>json</type>
+                  <classifier>${configurations.corpus.classifier}</classifier>
                 </artifact>
               </artifacts>
             </configuration>

--- a/sonar-analyzer-commons-configurations/src/main/assembly/npm.xml
+++ b/sonar-analyzer-commons-configurations/src/main/assembly/npm.xml
@@ -20,5 +20,10 @@
       <outputDirectory>package</outputDirectory>
       <destName>secret-patterns.json</destName>
     </file>
+    <file>
+      <source>${project.build.directory}/generated-resources/secret-exclusion-corpus.json</source>
+      <outputDirectory>package</outputDirectory>
+      <destName>secret-exclusion-corpus.json</destName>
+    </file>
   </files>
 </assembly>

--- a/sonar-analyzer-commons-configurations/src/main/assembly/npm.xml
+++ b/sonar-analyzer-commons-configurations/src/main/assembly/npm.xml
@@ -16,6 +16,11 @@
       <destName>package.json</destName>
     </file>
     <file>
+      <source>${project.build.directory}/packaging/npm/README.md</source>
+      <outputDirectory>package</outputDirectory>
+      <destName>README.md</destName>
+    </file>
+    <file>
       <source>${project.build.directory}/generated-resources/secret-patterns.json</source>
       <outputDirectory>package</outputDirectory>
       <destName>secret-patterns.json</destName>

--- a/sonar-analyzer-commons-configurations/src/main/assembly/nupkg.xml
+++ b/sonar-analyzer-commons-configurations/src/main/assembly/nupkg.xml
@@ -35,6 +35,11 @@
       <destName>secret-patterns.json</destName>
     </file>
     <file>
+      <source>${project.build.directory}/generated-resources/secret-exclusion-corpus.json</source>
+      <outputDirectory>content</outputDirectory>
+      <destName>secret-exclusion-corpus.json</destName>
+    </file>
+    <file>
       <source>${project.build.directory}/packaging/nuget/README.md</source>
       <outputDirectory>./</outputDirectory>
       <destName>README.md</destName>

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/JsonExports.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/JsonExports.java
@@ -16,12 +16,11 @@
  */
 package org.sonarsource.analyzer.commons.appsec.export;
 
-import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -29,16 +28,16 @@ import java.util.List;
 
 final class JsonExports {
 
-  /**
-   * Pretty-printed so the generated artifacts diff cleanly, with HTML escaping disabled so regex metacharacters stay
-   * readable rather than being emitted as {@code <} escapes.
-   */
-  static final Gson GSON = new GsonBuilder()
-    .setPrettyPrinting()
-    .disableHtmlEscaping()
-    .create();
-
   private JsonExports() {
+    // util class
+  }
+
+  static String render(JsonObject root) {
+    return new GsonBuilder()
+      .setPrettyPrinting()
+      .disableHtmlEscaping()
+      .create()
+      .toJson(root) + "\n";
   }
 
   static JsonArray toArray(List<String> values) {
@@ -51,7 +50,7 @@ final class JsonExports {
     Path output = Paths.get(path).toAbsolutePath();
     try {
       Files.createDirectories(output.getParent());
-      Files.write(output, content.getBytes(StandardCharsets.UTF_8));
+      Files.writeString(output, content);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/JsonExports.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/JsonExports.java
@@ -1,0 +1,59 @@
+/*
+ * SonarSource Analyzers Commons Configurations
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.analyzer.commons.appsec.export;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+final class JsonExports {
+
+  /**
+   * Pretty-printed so the generated artifacts diff cleanly, with HTML escaping disabled so regex metacharacters stay
+   * readable rather than being emitted as {@code <} escapes.
+   */
+  static final Gson GSON = new GsonBuilder()
+    .setPrettyPrinting()
+    .disableHtmlEscaping()
+    .create();
+
+  private JsonExports() {
+  }
+
+  static JsonArray toArray(List<String> values) {
+    JsonArray array = new JsonArray();
+    values.forEach(array::add);
+    return array;
+  }
+
+  static void write(String path, String content) {
+    Path output = Paths.get(path).toAbsolutePath();
+    try {
+      Files.createDirectories(output.getParent());
+      Files.write(output, content.getBytes(StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretExclusionCorpusExporter.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretExclusionCorpusExporter.java
@@ -53,26 +53,26 @@ public final class SecretExclusionCorpusExporter {
   }
 
   /**
-   * Builds the JSON document from the classifier's exported samples. The known non-secrets are flattened to one entry
-   * per value, each carrying its category, rather than nested per category: consumers assert on the values and would
-   * otherwise all have to flatten the groups themselves.
+   * Builds the JSON document from the classifier's exported samples, in {@link SecretClassifier.Category} declaration
+   * order. The known non-secrets are flattened to one entry per value, each carrying its category, rather than nested
+   * per category: consumers assert on the values and would otherwise all have to flatten the groups themselves.
    */
   public static String toJson() {
     JsonObject root = new JsonObject();
     root.addProperty("description", DESCRIPTION);
 
     JsonArray knownNonSecrets = new JsonArray();
-    for (SecretClassifier.SampleGroupView group : SecretClassifier.exportKnownNonSecretSamples()) {
-      for (String value : group.values()) {
+    for (SecretClassifier.Category category : SecretClassifier.Category.values()) {
+      for (String value : SecretClassifier.exportKnownNonSecretSamples(category)) {
         JsonObject sample = new JsonObject();
         sample.addProperty("value", value);
-        sample.addProperty("category", group.category());
+        sample.addProperty("category", category.name());
         knownNonSecrets.add(sample);
       }
     }
     root.add("knownNonSecrets", knownNonSecrets);
     root.add("secretCandidates", JsonExports.toArray(SecretClassifier.exportSecretCandidateSamples()));
 
-    return JsonExports.GSON.toJson(root) + "\n";
+    return JsonExports.render(root);
   }
 }

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretExclusionCorpusExporter.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretExclusionCorpusExporter.java
@@ -37,9 +37,10 @@ public final class SecretExclusionCorpusExporter {
 
   private static final String DESCRIPTION = "Validation corpus for secret-patterns.json, generated from " +
     "SecretClassifier in sonar-analyzer-commons. Do not edit by hand. Every \"knownNonSecrets\" value must be " +
-    "suppressed by the patterns in secret-patterns.json, and no \"secretCandidates\" value may be. A known " +
-    "non-secret's \"category\" records which pattern group suppresses it in the JVM implementation, which is " +
-    "first-match-wins; it is informational and not part of the contract.";
+    "suppressed by secret-patterns.json - either matched by a \"patternGroups\" regex or equal to an " +
+    "\"exactMatchGroups\" value, following the \"match\" semantics declared there - and no \"secretCandidates\" " +
+    "value may be. A known non-secret's \"category\" records which pattern group suppresses it in the JVM " +
+    "implementation, which is first-match-wins; it is informational and not part of the contract.";
 
   private SecretExclusionCorpusExporter() {
   }

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretExclusionCorpusExporter.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretExclusionCorpusExporter.java
@@ -1,0 +1,77 @@
+/*
+ * SonarSource Analyzers Commons Configurations
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.analyzer.commons.appsec.export;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.sonarsource.analyzer.commons.appsec.SecretClassifier;
+
+/**
+ * Generates the validation corpus published next to {@code secret-patterns.json}: the sample values whose
+ * classification the patterns must reproduce, in every engine that consumes the export.
+ *
+ * <p>Exporting the patterns alone is not enough to keep non-JVM analyzers in sync. A regex that fails to compile, or
+ * that behaves differently, in .NET or JavaScript changes what gets suppressed with no signal at all - SonarJS, for
+ * one, drops patterns its engine rejects. The corpus turns that into a test: {@code knownNonSecrets} must all be
+ * suppressed, and {@code secretCandidates} must all survive. The second half matters as much as the first, because a
+ * pattern that is too broad in a foreign engine hides real hardcoded secrets rather than merely adding noise.
+ *
+ * <p>Output is deterministic and pretty-printed so the artifact diffs cleanly. Run via {@code exec:java} at build time;
+ * {@code main} takes the target file path as its single argument.
+ */
+public final class SecretExclusionCorpusExporter {
+
+  private static final String DESCRIPTION = "Validation corpus for secret-patterns.json, generated from " +
+    "SecretClassifier in sonar-analyzer-commons. Do not edit by hand. Every \"knownNonSecrets\" value must be " +
+    "suppressed by the patterns in secret-patterns.json, and no \"secretCandidates\" value may be. A known " +
+    "non-secret's \"category\" records which pattern group suppresses it in the JVM implementation, which is " +
+    "first-match-wins; it is informational and not part of the contract.";
+
+  private SecretExclusionCorpusExporter() {
+  }
+
+  public static void main(String[] args) {
+    if (args.length < 1) {
+      throw new IllegalArgumentException("Usage: SecretExclusionCorpusExporter <output-json-path>");
+    }
+    JsonExports.write(args[0], toJson());
+  }
+
+  /**
+   * Builds the JSON document from the classifier's exported samples. The known non-secrets are flattened to one entry
+   * per value, each carrying its category, rather than nested per category: consumers assert on the values and would
+   * otherwise all have to flatten the groups themselves.
+   */
+  public static String toJson() {
+    JsonObject root = new JsonObject();
+    root.addProperty("description", DESCRIPTION);
+
+    JsonArray knownNonSecrets = new JsonArray();
+    for (SecretClassifier.SampleGroupView group : SecretClassifier.exportKnownNonSecretSamples()) {
+      for (String value : group.values()) {
+        JsonObject sample = new JsonObject();
+        sample.addProperty("value", value);
+        sample.addProperty("category", group.category());
+        knownNonSecrets.add(sample);
+      }
+    }
+    root.add("knownNonSecrets", knownNonSecrets);
+    root.add("secretCandidates", JsonExports.toArray(SecretClassifier.exportSecretCandidateSamples()));
+
+    return JsonExports.GSON.toJson(root) + "\n";
+  }
+}

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporter.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporter.java
@@ -89,7 +89,7 @@ public final class SecretPatternsExporter {
     }
     root.add("exactMatchGroups", exactMatchGroups);
 
-    return JsonExports.GSON.toJson(root) + "\n";
+    return JsonExports.render(root);
   }
 
   private static List<String> translate(List<String> regexes) {

--- a/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporter.java
+++ b/sonar-analyzer-commons-configurations/src/main/java/org/sonarsource/analyzer/commons/appsec/export/SecretPatternsExporter.java
@@ -16,16 +16,8 @@
  */
 package org.sonarsource.analyzer.commons.appsec.export;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.sonarsource.analyzer.commons.appsec.SecretClassifier;
@@ -42,17 +34,15 @@ import org.sonarsource.analyzer.commons.appsec.SecretClassifier;
  *
  * <p>Output is deterministic and pretty-printed so the artifact diffs cleanly. Run via {@code exec:java} at build time;
  * {@code main} takes the target file path as its single argument.
+ *
+ * <p>The samples that these patterns must reproduce in every engine are published separately by
+ * {@link SecretExclusionCorpusExporter}.
  */
 public final class SecretPatternsExporter {
 
   private static final String DESCRIPTION = "Secret-exclusion patterns generated from SecretClassifier in " +
     "sonar-analyzer-commons. Do not edit by hand. Regexes are applied case-insensitively with \"find\" " +
     "(search-anywhere) semantics; exact values are matched in full, case-insensitively.";
-
-  private static final Gson GSON = new GsonBuilder()
-    .setPrettyPrinting()
-    .disableHtmlEscaping()
-    .create();
 
   private SecretPatternsExporter() {
   }
@@ -61,13 +51,7 @@ public final class SecretPatternsExporter {
     if (args.length < 1) {
       throw new IllegalArgumentException("Usage: SecretPatternsExporter <output-json-path>");
     }
-    Path output = Paths.get(args[0]).toAbsolutePath();
-    try {
-      Files.createDirectories(output.getParent());
-      Files.write(output, toJson().getBytes(StandardCharsets.UTF_8));
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    JsonExports.write(args[0], toJson());
   }
 
   /**
@@ -91,7 +75,7 @@ public final class SecretPatternsExporter {
     for (SecretClassifier.PatternGroupView group : SecretClassifier.exportPatternGroups()) {
       JsonObject json = new JsonObject();
       json.addProperty("category", group.category());
-      json.add("patterns", toArray(translate(group.regexes())));
+      json.add("patterns", JsonExports.toArray(translate(group.regexes())));
       patternGroups.add(json);
     }
     root.add("patternGroups", patternGroups);
@@ -100,18 +84,12 @@ public final class SecretPatternsExporter {
     for (SecretClassifier.ExactMatchGroupView group : SecretClassifier.exportExactMatchGroups()) {
       JsonObject json = new JsonObject();
       json.addProperty("category", group.category());
-      json.add("values", toArray(group.values()));
+      json.add("values", JsonExports.toArray(group.values()));
       exactMatchGroups.add(json);
     }
     root.add("exactMatchGroups", exactMatchGroups);
 
-    return GSON.toJson(root) + "\n";
-  }
-
-  private static JsonArray toArray(List<String> values) {
-    JsonArray array = new JsonArray();
-    values.forEach(array::add);
-    return array;
+    return JsonExports.GSON.toJson(root) + "\n";
   }
 
   private static List<String> translate(List<String> regexes) {

--- a/sonar-analyzer-commons-configurations/src/main/packaging/npm/README.md
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/npm/README.md
@@ -1,0 +1,15 @@
+# @sonarsource/analyzer-commons-configurations
+
+Shared analyzer configuration data (secret-exclusion regexes) generated from the sonar-analyzer-commons
+SecretClassifier, for use by non-JVM SonarSource analyzers.
+
+The payload is `secret-patterns.json`.
+
+`secret-exclusion-corpus.json` is the matching validation corpus. Every `knownNonSecrets` value must be suppressed by
+`secret-patterns.json` in your regex engine - either matched by a `patternGroups` regex or equal to an
+`exactMatchGroups` value, following the `match` semantics declared in that file - and no `secretCandidates` value may
+be. Assert both in your own test suite, so a pattern that fails to compile or behaves differently outside the JVM is
+caught here rather than becoming a missed or a noisy secret finding. A sample's `category` is informational and should
+not be asserted on.
+
+See [SonarSource/sonar-analyzer-commons](https://github.com/SonarSource/sonar-analyzer-commons) for details.

--- a/sonar-analyzer-commons-configurations/src/main/packaging/npm/package.json
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/npm/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@sonarsource/analyzer-commons-configurations",
   "version": "${npm.package.version}",
-  "description": "Shared analyzer configuration data (secret-exclusion regexes) generated from the sonar-analyzer-commons SecretClassifier, for use by non-JVM SonarSource analyzers.",
+  "description": "Shared analyzer configuration data (secret-exclusion regexes) generated from the sonar-analyzer-commons SecretClassifier, for use by non-JVM SonarSource analyzers. The payload is secret-patterns.json, with the sample values those patterns must reproduce in secret-exclusion-corpus.json.",
   "license": "LGPL-3.0-only",
   "files": [
+    "README.md",
     "secret-patterns.json",
     "secret-exclusion-corpus.json"
   ],

--- a/sonar-analyzer-commons-configurations/src/main/packaging/npm/package.json
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/npm/package.json
@@ -4,7 +4,8 @@
   "description": "Shared analyzer configuration data (secret-exclusion regexes) generated from the sonar-analyzer-commons SecretClassifier, for use by non-JVM SonarSource analyzers.",
   "license": "LGPL-3.0-only",
   "files": [
-    "secret-patterns.json"
+    "secret-patterns.json",
+    "secret-exclusion-corpus.json"
   ],
   "repository": {
     "type": "git",

--- a/sonar-analyzer-commons-configurations/src/main/packaging/nuget/README.md
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/nuget/README.md
@@ -5,4 +5,9 @@ SecretClassifier, for use by non-JVM SonarSource analyzers.
 
 The payload is `content/secret-patterns.json`.
 
+`content/secret-exclusion-corpus.json` is the matching validation corpus. Every `knownNonSecrets` value must be
+suppressed by those patterns in your regex engine, and no `secretCandidates` value may be - assert both in your own
+test suite, so a pattern that fails to compile or behaves differently outside the JVM is caught here rather than
+becoming a missed or a noisy secret finding. A sample's `category` is informational and should not be asserted on.
+
 See [SonarSource/sonar-analyzer-commons](https://github.com/SonarSource/sonar-analyzer-commons) for details.

--- a/sonar-analyzer-commons-configurations/src/main/packaging/nuget/README.md
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/nuget/README.md
@@ -6,8 +6,10 @@ SecretClassifier, for use by non-JVM SonarSource analyzers.
 The payload is `content/secret-patterns.json`.
 
 `content/secret-exclusion-corpus.json` is the matching validation corpus. Every `knownNonSecrets` value must be
-suppressed by those patterns in your regex engine, and no `secretCandidates` value may be - assert both in your own
-test suite, so a pattern that fails to compile or behaves differently outside the JVM is caught here rather than
-becoming a missed or a noisy secret finding. A sample's `category` is informational and should not be asserted on.
+suppressed by `secret-patterns.json` in your regex engine - either matched by a `patternGroups` regex or equal to an
+`exactMatchGroups` value, following the `match` semantics declared in that file - and no `secretCandidates` value may
+be. Assert both in your own test suite, so a pattern that fails to compile or behaves differently outside the JVM is
+caught here rather than becoming a missed or a noisy secret finding. A sample's `category` is informational and should
+not be asserted on.
 
 See [SonarSource/sonar-analyzer-commons](https://github.com/SonarSource/sonar-analyzer-commons) for details.

--- a/sonar-analyzer-commons-configurations/src/main/packaging/nuget/sonar-analyzer-commons-configurations.nuspec
+++ b/sonar-analyzer-commons-configurations/src/main/packaging/nuget/sonar-analyzer-commons-configurations.nuspec
@@ -12,7 +12,8 @@
     <projectUrl>https://github.com/SonarSource/sonar-analyzer-commons</projectUrl>
     <readme>README.md</readme>
     <description>Shared analyzer configuration data (secret-exclusion regexes) generated from the sonar-analyzer-commons
-      SecretClassifier, for use by non-JVM SonarSource analyzers. The payload is content/secret-patterns.json.</description>
+      SecretClassifier, for use by non-JVM SonarSource analyzers. The payload is content/secret-patterns.json, with the
+      sample values those patterns must reproduce in content/secret-exclusion-corpus.json.</description>
     <tags>sonarsource analyzer secrets configuration</tags>
   </metadata>
 </package>

--- a/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslatorTest.java
+++ b/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslatorTest.java
@@ -29,25 +29,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RegexTranslatorTest {
-  private static final List<String> SAMPLES = List.of(
-    "", "abc", "samplepassword", "EXAMPLE_SECRET", "deadbeef", "qwerty",
-    "password1234", "passwd", "undefined", "true", "null", "yourpassword",
-    "abbbbc", "111111", "1fj28...askn3i", "TODO: replace me", "FIXME",
-    "admin123", "vncpass", "super-secret-p4ssw0rd",
-    "hunter2", "letmein", "abc123", "changeme", "changeit", "unknown", "optional",
-    "enabled", "disabled", "string", "random", "token",
-    "${secret}", "value-${pwd}", "#{{secret}}", "((db-password))",
-    "$(echo $PASSWORD)", "`echo $PASSWORD`", "$foo_bar",
-    "{secret}", "%{secret}", "{{secret}}",
-    "System.getenv(\"secret\")", "process.env.MY_SECRET", "%GITHUB_TOKEN%", "config['secret']", "Read-Host",
-    "<password>", "(password)", "[password]", "%(password)s", "@variables('name')",
-    "encrypted:YWJjZGVm", "{cipher}1e3faa2cdab2deae117dca102e52922a", "enc[QUJDRA==]", "ENC{abcdef}",
-    "%enc{QUJDRA==}", "ENC(abcdef)",
-    "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-pass", "op://vault/item/password",
-    "VAULT[path/to/secret access_token]",
-    "/var/keys/gsa-key.json", "v1.2.3", ">=1.0.0", "~1.4.5-alpha", "4.0.9(@types/node@22.13.4)",
-    // realistic values that should NOT be excluded
-    "Xk9Lm2Qp7Rs4Tv1Wz0", "9f8e7d6c5b4a392817", "Tr0ub4dor&3xpl0!t", "mytoken123", "this_should_remain_unknown");
+  /**
+   * Translation edge cases the published corpus cannot carry: every corpus sample must classify under the category it
+   * is declared in, and {@code "FIXME"} is caught by the minimum-length pattern first. It is kept here because it is
+   * the only sample that puts a {@code \b} at end of input, a boundary engines can disagree on.
+   */
+  private static final List<String> TRANSLATION_EDGE_CASES = List.of("FIXME");
+
+  /**
+   * Derived from the published validation corpus rather than hand-copied, so a sample added there is exercised here
+   * too - this class is the guard that translation preserves matching, and a duplicated list silently drifts.
+   */
+  private static final List<String> SAMPLES = Stream.of(
+    SecretClassifier.exportKnownNonSecretSamples().stream().flatMap(group -> group.values().stream()).toList(),
+    SecretClassifier.exportSecretCandidateSamples(),
+    TRANSLATION_EDGE_CASES)
+    .flatMap(List::stream)
+    .toList();
 
   static Stream<Arguments> translationCases() {
     return Stream.of(

--- a/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslatorTest.java
+++ b/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslatorTest.java
@@ -34,7 +34,8 @@ class RegexTranslatorTest {
    * too - this class is the guard that translation preserves matching, and a duplicated list silently drifts.
    */
   private static final List<String> SAMPLES = Stream.concat(
-    SecretClassifier.exportKnownNonSecretSamples().stream().flatMap(group -> group.values().stream()),
+    Stream.of(SecretClassifier.Category.values())
+      .flatMap(category -> SecretClassifier.exportKnownNonSecretSamples(category).stream()),
     SecretClassifier.exportSecretCandidateSamples().stream())
     .toList();
 

--- a/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslatorTest.java
+++ b/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/RegexTranslatorTest.java
@@ -30,21 +30,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RegexTranslatorTest {
   /**
-   * Translation edge cases the published corpus cannot carry: every corpus sample must classify under the category it
-   * is declared in, and {@code "FIXME"} is caught by the minimum-length pattern first. It is kept here because it is
-   * the only sample that puts a {@code \b} at end of input, a boundary engines can disagree on.
-   */
-  private static final List<String> TRANSLATION_EDGE_CASES = List.of("FIXME");
-
-  /**
    * Derived from the published validation corpus rather than hand-copied, so a sample added there is exercised here
    * too - this class is the guard that translation preserves matching, and a duplicated list silently drifts.
    */
-  private static final List<String> SAMPLES = Stream.of(
-    SecretClassifier.exportKnownNonSecretSamples().stream().flatMap(group -> group.values().stream()).toList(),
-    SecretClassifier.exportSecretCandidateSamples(),
-    TRANSLATION_EDGE_CASES)
-    .flatMap(List::stream)
+  private static final List<String> SAMPLES = Stream.concat(
+    SecretClassifier.exportKnownNonSecretSamples().stream().flatMap(group -> group.values().stream()),
+    SecretClassifier.exportSecretCandidateSamples().stream())
     .toList();
 
   static Stream<Arguments> translationCases() {
@@ -188,7 +179,6 @@ class RegexTranslatorTest {
       assertThat(RegexTranslator.toPortableRegex(once)).isEqualTo(once);
     }
   }
-
 
   @Test
   void translatedPatternsShouldMatchTheSameSamplesAsTheSource() {

--- a/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/SecretExclusionCorpusExporterTest.java
+++ b/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/SecretExclusionCorpusExporterTest.java
@@ -1,0 +1,187 @@
+/*
+ * SonarSource Analyzers Commons Configurations
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonarsource.analyzer.commons.appsec.export;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonarsource.analyzer.commons.appsec.SecretClassifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Covers the corpus export itself, and - more importantly - that the two published artifacts agree: the patterns in
+ * {@code secret-patterns.json} must reproduce the classification recorded in {@code secret-exclusion-corpus.json}
+ * <em>after</em> translation to their portable form, which is the form every consumer actually compiles.
+ */
+class SecretExclusionCorpusExporterTest {
+
+  @Test
+  void mainShouldWriteJsonToTheGivenPathCreatingMissingParents(@TempDir Path tempDir) throws IOException {
+    // The parent directory does not exist yet, so main() must create it (as it does under target/ at build time).
+    Path output = tempDir.resolve("generated-resources").resolve("secret-exclusion-corpus.json");
+
+    SecretExclusionCorpusExporter.main(new String[] {output.toString()});
+
+    assertThat(output).exists();
+    assertThat(Files.readString(output)).isEqualTo(SecretExclusionCorpusExporter.toJson());
+  }
+
+  @Test
+  void mainShouldFailWhenNoOutputPathIsGiven() {
+    assertThatThrownBy(() -> SecretExclusionCorpusExporter.main(new String[0]))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Usage");
+  }
+
+  @Test
+  void jsonShouldBeDeterministic() {
+    assertThat(SecretExclusionCorpusExporter.toJson()).isEqualTo(SecretExclusionCorpusExporter.toJson());
+  }
+
+  @Test
+  void jsonShouldBeWellFormedAndPrettyPrinted() throws ParseException {
+    String json = SecretExclusionCorpusExporter.toJson();
+
+    assertThat(new JSONParser().parse(json)).isInstanceOf(JSONObject.class);
+    assertThat(json)
+      .startsWith("{\n")
+      .contains("\n  \"")
+      .endsWith("}\n");
+  }
+
+  @Test
+  void jsonShouldExposeTheExpectedTopLevelStructure() throws ParseException {
+    JSONObject root = parseCorpus();
+
+    assertThat(root).containsOnlyKeys("description", "knownNonSecrets", "secretCandidates");
+    assertThat(root.get("description")).asString().contains("Do not edit by hand");
+    assertThat((JSONArray) root.get("knownNonSecrets")).isNotEmpty();
+    assertThat((JSONArray) root.get("secretCandidates")).isNotEmpty();
+  }
+
+  @Test
+  void knownNonSecretsShouldMirrorSecretClassifierSamplesWithTheirCategory() throws ParseException {
+    List<JSONObject> expected = new ArrayList<>();
+    for (SecretClassifier.SampleGroupView group : SecretClassifier.exportKnownNonSecretSamples()) {
+      for (String value : group.values()) {
+        JSONObject sample = new JSONObject();
+        sample.put("value", value);
+        sample.put("category", group.category());
+        expected.add(sample);
+      }
+    }
+
+    assertThat((JSONArray) parseCorpus().get("knownNonSecrets")).containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  void secretCandidatesShouldMirrorSecretClassifier() throws ParseException {
+    assertThat((JSONArray) parseCorpus().get("secretCandidates"))
+      .containsExactlyElementsOf(SecretClassifier.exportSecretCandidateSamples());
+  }
+
+  @Test
+  void everyExportedPatternAndExactValueShouldBeExercisedByTheCorpus() throws ParseException {
+    List<String> knownNonSecrets = knownNonSecretValues();
+
+    for (Pattern pattern : exportedPatterns()) {
+      assertThat(knownNonSecrets)
+        .as("no corpus sample exercises exported pattern: %s", pattern.pattern())
+        .anyMatch(sample -> pattern.matcher(sample).find());
+    }
+    for (String exact : exportedExactValues()) {
+      assertThat(knownNonSecrets)
+        .as("no corpus sample exercises exported exact value: %s", exact)
+        .anyMatch(sample -> sample.equalsIgnoreCase(exact));
+    }
+  }
+
+  /**
+   * The contract consumers rely on, checked against the exported (portable) regexes rather than the classifier's own:
+   * a translation that changed a match would otherwise only surface in a downstream repository.
+   */
+  @Test
+  void exportedPatternsShouldReproduceTheCorpusClassification() throws ParseException {
+    List<Pattern> patterns = exportedPatterns();
+    List<String> exactValues = exportedExactValues();
+
+    for (String sample : knownNonSecretValues()) {
+      assertThat(isSuppressed(sample, patterns, exactValues))
+        .as("corpus known non-secret is not suppressed by the exported patterns: <%s>", sample)
+        .isTrue();
+    }
+    for (Object candidate : (JSONArray) parseCorpus().get("secretCandidates")) {
+      String sample = (String) candidate;
+      assertThat(isSuppressed(sample, patterns, exactValues))
+        .as("corpus secret candidate is suppressed by the exported patterns: <%s>", sample)
+        .isFalse();
+    }
+  }
+
+  private static boolean isSuppressed(String sample, List<Pattern> patterns, List<String> exactValues) {
+    return exactValues.stream().anyMatch(sample::equalsIgnoreCase)
+      || patterns.stream().anyMatch(pattern -> pattern.matcher(sample).find());
+  }
+
+  private static List<String> knownNonSecretValues() throws ParseException {
+    List<String> values = new ArrayList<>();
+    for (Object sample : (JSONArray) parseCorpus().get("knownNonSecrets")) {
+      values.add((String) ((JSONObject) sample).get("value"));
+    }
+    return values;
+  }
+
+  /** The patterns exactly as published, compiled the way the export declares they must be applied. */
+  private static List<Pattern> exportedPatterns() throws ParseException {
+    List<Pattern> patterns = new ArrayList<>();
+    for (Object group : (JSONArray) parsePatterns().get("patternGroups")) {
+      for (Object pattern : (JSONArray) ((JSONObject) group).get("patterns")) {
+        patterns.add(Pattern.compile((String) pattern, Pattern.CASE_INSENSITIVE));
+      }
+    }
+    return patterns;
+  }
+
+  private static List<String> exportedExactValues() throws ParseException {
+    List<String> values = new ArrayList<>();
+    for (Object group : (JSONArray) parsePatterns().get("exactMatchGroups")) {
+      for (Object value : (JSONArray) ((JSONObject) group).get("values")) {
+        values.add((String) value);
+      }
+    }
+    return values;
+  }
+
+  private static JSONObject parseCorpus() throws ParseException {
+    return (JSONObject) new JSONParser().parse(SecretExclusionCorpusExporter.toJson());
+  }
+
+  private static JSONObject parsePatterns() throws ParseException {
+    return (JSONObject) new JSONParser().parse(SecretPatternsExporter.toJson());
+  }
+}

--- a/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/SecretExclusionCorpusExporterTest.java
+++ b/sonar-analyzer-commons-configurations/src/test/java/org/sonarsource/analyzer/commons/appsec/export/SecretExclusionCorpusExporterTest.java
@@ -87,11 +87,11 @@ class SecretExclusionCorpusExporterTest {
   @Test
   void knownNonSecretsShouldMirrorSecretClassifierSamplesWithTheirCategory() throws ParseException {
     List<JSONObject> expected = new ArrayList<>();
-    for (SecretClassifier.SampleGroupView group : SecretClassifier.exportKnownNonSecretSamples()) {
-      for (String value : group.values()) {
+    for (SecretClassifier.Category category : SecretClassifier.Category.values()) {
+      for (String value : SecretClassifier.exportKnownNonSecretSamples(category)) {
         JSONObject sample = new JSONObject();
         sample.put("value", value);
-        sample.put("category", group.category());
+        sample.put("category", category.name());
         expected.add(sample);
       }
     }


### PR DESCRIPTION


Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **New features:**
    - Added `SecretExclusionCorpusExporter` to publish validation corpus JSON for non-JVM analyzers
    - Bundled `secret-exclusion-corpus.json` into npm and NuGet packages alongside `secret-patterns.json`
- **Refactoring:**
    - Moved shared Gson utilities into `JsonExports` class
    - Relocated classification samples from test scope into `SecretClassifier` main scope

<sub>This will update automatically on new commits.</sub>