### PR TITLE
ACOMMONS-146 Remove redundant logging dependency handling

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -21,11 +21,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>26.1.0</version>

--- a/performance-measure/pom.xml
+++ b/performance-measure/pom.xml
@@ -25,11 +25,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>
       <artifactId>sonar-plugin-api-test-fixtures</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -100,12 +100,6 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>2.0.18</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>org.sonarsource.scanner.engine</groupId>
         <artifactId>plugin-api-scanner-impl</artifactId>
         <version>${version.sonar.scanner}</version>

--- a/regex-parsing/pom.xml
+++ b/regex-parsing/pom.xml
@@ -18,11 +18,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>

--- a/test-xml-parsing/pom.xml
+++ b/test-xml-parsing/pom.xml
@@ -18,11 +18,6 @@
       <artifactId>sonar-plugin-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.sonarsource.scanner.engine</groupId>

--- a/xml-parsing/pom.xml
+++ b/xml-parsing/pom.xml
@@ -18,11 +18,6 @@
       <artifactId>sonar-plugin-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Part of

## Summary

- Remove redundant explicit SLF4J declarations from Plugin API-bound modules.
- Rely on Sonar Plugin API v14 to provide SLF4J 2.0.18 as part of the platform contract.
