### PR TITLE
ACOMMONS-153 Add jabber.org and apache.org XML feature URLs as safe cleartext identifiers

### DIFF
--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -164,14 +164,15 @@ public final class CleartextProtocolFilter {
 
   // --- Well-known identifier URLs (host + path) -------------------------------------------
   // Unlike the namespace URI authorities above, these hosts also serve ordinary content,
-  // so only the specific path(s) below — opaque protocol/feature identifiers, not real
-  // endpoints — are considered safe. Matched against "host + path" of the URI.
+  // so only the specific path prefix(es) below — opaque protocol/feature identifiers, not
+  // real endpoints — are considered safe. Matched against "host + path" of the URI.
   private static final Pattern SAFE_URL_PATH_PREFIXES = Pattern.compile("(?:" +
     // XMPP protocol namespaces (XEPs)
     "^jabber\\.org/protocol/|" +
-    // Xerces/JAXP XML parser features to disable DTD loading
-    "^apache\\.org/xml/features/nonvalidating/load-dtd-grammar$|" +
-    "^apache\\.org/xml/features/nonvalidating/load-external-dtd$" +
+    // Xerces/JAXP XML parser feature flags (nonvalidating/load-external-dtd,
+    // disallow-doctype-decl, dom/create-entity-ref-nodes, …) — opaque identifiers,
+    // never real HTTP endpoints: https://xerces.apache.org/xerces2-j/features.html
+    "^apache\\.org/xml/features/" +
     ")", Pattern.CASE_INSENSITIVE);
 
   // --- IANA-reserved documentation / placeholder domains --------------------------------
@@ -278,7 +279,10 @@ public final class CleartextProtocolFilter {
     }
     var matcher = CLEARTEXT_AUTHORITY.matcher(stripped);
     if (matcher.find()) {
-      return isSafeHost(matcher.group("rest"));
+      var rest = matcher.group("rest");
+      var path = stripped.substring(matcher.end()).split("[?#]", 2)[0];
+      var host = rest.replaceFirst(":\\d*$", "");
+      return isSafeHost(rest) || isKnownIdentifierUrl(host, path);
     }
     var lower = stripped.toLowerCase(Locale.ROOT);
     return CLEARTEXT_SCHEME_PREFIXES.stream().noneMatch(lower::startsWith);

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -47,6 +47,11 @@ import java.util.stream.Collectors;
  *       OASIS, HL7, …) whose {@code http://} URIs are opaque namespace identifiers
  *       used in XML, JSON-LD, RDF, and similar formats. They carry a protocol prefix
  *       by convention and do not imply an actual HTTP connection.</li>
+ *   <li><b>Well-known identifier URLs</b> — specific {@code http://} URLs (or URL
+ *       prefixes) that are opaque protocol/feature identifiers rather than real
+ *       endpoints, on hosts that otherwise serve ordinary content (e.g. XMPP
+ *       protocol namespaces under {@code jabber.org/protocol/}, or Xerces/JAXP XML
+ *       parser feature flags under {@code apache.org/xml/features/}).</li>
  *   <li><b>IANA-reserved documentation domains</b> — {@code example.com},
  *       {@code example.net}, and {@code example.org} and their subdomains, plus the
  *       reserved TLDs {@code .example}, {@code .test}, and {@code .localhost} (RFC 6761).
@@ -156,6 +161,18 @@ public final class CleartextProtocolFilter {
     // Eclipse EMF/Ecore
     "^www\\.eclipse\\.org" +
     ")(?=:|$)", Pattern.CASE_INSENSITIVE);
+
+  // --- Well-known identifier URLs (host + path) -------------------------------------------
+  // Unlike the namespace URI authorities above, these hosts also serve ordinary content,
+  // so only the specific path(s) below — opaque protocol/feature identifiers, not real
+  // endpoints — are considered safe. Matched against "host + path" of the URI.
+  private static final Pattern SAFE_URL_PATH_PREFIXES = Pattern.compile("(?:" +
+    // XMPP protocol namespaces (XEPs)
+    "^jabber\\.org/protocol/|" +
+    // Xerces/JAXP XML parser features to disable DTD loading
+    "^apache\\.org/xml/features/nonvalidating/load-dtd-grammar$|" +
+    "^apache\\.org/xml/features/nonvalidating/load-external-dtd$" +
+    ")", Pattern.CASE_INSENSITIVE);
 
   // --- IANA-reserved documentation / placeholder domains --------------------------------
   // example.com/net/org are well-known IANA-delegated documentation domains.
@@ -282,7 +299,7 @@ public final class CleartextProtocolFilter {
     if (host == null) {
       return false;
     }
-    return isSafeHost(host) || isSingleLabelHost(host);
+    return isSafeHost(host) || isSingleLabelHost(host) || isKnownIdentifierUrl(host, url.getRawPath());
   }
 
   private static boolean isSafeHost(String host) {
@@ -310,6 +327,11 @@ public final class CleartextProtocolFilter {
 
   private static boolean isNamespaceUriAuthority(String host) {
     return NAMESPACE_URI_AUTHORITIES.matcher(host).find();
+  }
+
+  private static boolean isKnownIdentifierUrl(String host, String path) {
+    var hostAndPath = host + (path == null ? "" : path);
+    return SAFE_URL_PATH_PREFIXES.matcher(hostAndPath).find();
   }
 
   private static boolean isDocumentationHost(String host) {

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -162,18 +162,18 @@ public final class CleartextProtocolFilter {
     "^www\\.eclipse\\.org" +
     ")(?=:|$)", Pattern.CASE_INSENSITIVE);
 
-  // --- Well-known identifier URLs (host + path) -------------------------------------------
-  // Unlike the namespace URI authorities above, these hosts also serve ordinary content,
-  // so only the specific path prefix(es) below — opaque protocol/feature identifiers, not
-  // real endpoints — are considered safe. Matched against "host + path" of the URI.
-  private static final Pattern SAFE_URL_PATH_PREFIXES = Pattern.compile("(?:" +
+  // --- Well-known identifier URLs -------------------------------------------------------
+  // Unlike the namespace URI authorities above, these hosts also serve ordinary content, so
+  // only full http:// URLs starting with one of these prefixes — opaque protocol/feature
+  // identifiers, not real endpoints — are considered safe.
+  private static final Set<String> SAFE_URL_PREFIXES = Set.of(
     // XMPP protocol namespaces (XEPs)
-    "^jabber\\.org/protocol/|" +
+    "http://jabber.org/protocol/",
     // Xerces/JAXP XML parser feature flags (nonvalidating/load-external-dtd,
     // disallow-doctype-decl, dom/create-entity-ref-nodes, …) — opaque identifiers,
     // never real HTTP endpoints: https://xerces.apache.org/xerces2-j/features.html
-    "^apache\\.org/xml/features/" +
-    ")", Pattern.CASE_INSENSITIVE);
+    "http://apache.org/xml/features/"
+  );
 
   // --- IANA-reserved documentation / placeholder domains --------------------------------
   // example.com/net/org are well-known IANA-delegated documentation domains.
@@ -269,6 +269,9 @@ public final class CleartextProtocolFilter {
    */
   public static boolean isSafeWithoutTls(String url) {
     var stripped = url.strip();
+    if (isKnownIdentifierUrl(stripped)) {
+      return true;
+    }
     try {
       var uri = new URI(stripped);
       if (uri.getScheme() != null && uri.getHost() != null) {
@@ -279,10 +282,7 @@ public final class CleartextProtocolFilter {
     }
     var matcher = CLEARTEXT_AUTHORITY.matcher(stripped);
     if (matcher.find()) {
-      var rest = matcher.group("rest");
-      var path = stripped.substring(matcher.end()).split("[?#]", 2)[0];
-      var host = rest.replaceFirst(":\\d*$", "");
-      return isSafeHost(rest) || isKnownIdentifierUrl(host, path);
+      return isSafeHost(matcher.group("rest"));
     }
     var lower = stripped.toLowerCase(Locale.ROOT);
     return CLEARTEXT_SCHEME_PREFIXES.stream().noneMatch(lower::startsWith);
@@ -303,7 +303,10 @@ public final class CleartextProtocolFilter {
     if (host == null) {
       return false;
     }
-    return isSafeHost(host) || isSingleLabelHost(host) || isKnownIdentifierUrl(host, url.getRawPath());
+    if (isSafeHost(host) || isSingleLabelHost(host)) {
+      return true;
+    }
+    return isKnownIdentifierUrl(scheme + "://" + host + url.getRawPath());
   }
 
   private static boolean isSafeHost(String host) {
@@ -333,10 +336,9 @@ public final class CleartextProtocolFilter {
     return NAMESPACE_URI_AUTHORITIES.matcher(host).find();
   }
 
-  // path is never null here: URI.getRawPath() is non-null whenever getHost() is non-null,
-  // and the lenient fallback derives path from String.split(), which never returns null.
-  private static boolean isKnownIdentifierUrl(String host, String path) {
-    return SAFE_URL_PATH_PREFIXES.matcher(host + path).find();
+  private static boolean isKnownIdentifierUrl(String url) {
+    var lower = url.toLowerCase(Locale.ROOT);
+    return SAFE_URL_PREFIXES.stream().anyMatch(lower::startsWith);
   }
 
   private static boolean isDocumentationHost(String host) {

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -164,14 +164,11 @@ public final class CleartextProtocolFilter {
 
   // --- Well-known identifier URLs -------------------------------------------------------
   // Unlike the namespace URI authorities above, these hosts also serve ordinary content, so
-  // only full http:// URLs starting with one of these prefixes — opaque protocol/feature
-  // identifiers, not real endpoints — are considered safe.
+  // only full http:// URLs starting with one of these prefixes are considered safe.
   private static final Set<String> SAFE_URL_PREFIXES = Set.of(
     // XMPP protocol namespaces (XEPs)
     "http://jabber.org/protocol/",
-    // Xerces/JAXP XML parser feature flags (nonvalidating/load-external-dtd,
-    // disallow-doctype-decl, dom/create-entity-ref-nodes, …) — opaque identifiers,
-    // never real HTTP endpoints: https://xerces.apache.org/xerces2-j/features.html
+    // Xerces/JAXP XML parser feature flags
     "http://apache.org/xml/features/"
   );
 
@@ -303,10 +300,7 @@ public final class CleartextProtocolFilter {
     if (host == null) {
       return false;
     }
-    if (isSafeHost(host) || isSingleLabelHost(host)) {
-      return true;
-    }
-    return isKnownIdentifierUrl(scheme + "://" + host + url.getRawPath());
+    return isSafeHost(host) || isSingleLabelHost(host) || isKnownIdentifierUrl(url.toString());
   }
 
   private static boolean isSafeHost(String host) {

--- a/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
+++ b/commons/src/main/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilter.java
@@ -333,9 +333,10 @@ public final class CleartextProtocolFilter {
     return NAMESPACE_URI_AUTHORITIES.matcher(host).find();
   }
 
+  // path is never null here: URI.getRawPath() is non-null whenever getHost() is non-null,
+  // and the lenient fallback derives path from String.split(), which never returns null.
   private static boolean isKnownIdentifierUrl(String host, String path) {
-    var hostAndPath = host + (path == null ? "" : path);
-    return SAFE_URL_PATH_PREFIXES.matcher(hostAndPath).find();
+    return SAFE_URL_PATH_PREFIXES.matcher(host + path).find();
   }
 
   private static boolean isDocumentationHost(String host) {

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -364,9 +364,7 @@ class CleartextProtocolFilterTest {
       "http://apache.org/",
       "http://apache.org/xml/featuresx/disallow-doctype-decl",
       "http://apache.org.evil.com/xml/features/nonvalidating/load-dtd-grammar",
-      // Credentials before a known-identifier host — must not match: real endpoint could
-      // still be reached with attacker-supplied credentials, and the prefix check is only
-      // ever applied to the literal string, which now starts with the userinfo, not "http://"
+      // Credentials before a known-identifier host must not match
       "http://user:pass@jabber.org/protocol/muc",
       "http://user:pass@apache.org/xml/features/disallow-doctype-decl",
       // Template placeholder with a path outside the safe prefix — lenient fallback must not grant safety

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -313,7 +313,9 @@ class CleartextProtocolFilterTest {
       URI.create("http://2130706433"),
       // 8.8.8.8 as hexadecimal literal
       URI.create("http://0x08080808"),
-      URI.create("http://[2001:db8::1]")
+      URI.create("http://[2001:db8::1]"),
+      // Credentials before a known-identifier host so the prefix check does not match
+      URI.create("http://user:pass@jabber.org/protocol/muc")
     );
   }
 
@@ -362,6 +364,11 @@ class CleartextProtocolFilterTest {
       "http://apache.org/",
       "http://apache.org/xml/featuresx/disallow-doctype-decl",
       "http://apache.org.evil.com/xml/features/nonvalidating/load-dtd-grammar",
+      // Credentials before a known-identifier host — must not match: real endpoint could
+      // still be reached with attacker-supplied credentials, and the prefix check is only
+      // ever applied to the literal string, which now starts with the userinfo, not "http://"
+      "http://user:pass@jabber.org/protocol/muc",
+      "http://user:pass@apache.org/xml/features/disallow-doctype-decl",
       // Template placeholder with a path outside the safe prefix — lenient fallback must not grant safety
       "http://jabber.org/other/${x}",
 

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -216,6 +216,13 @@ class CleartextProtocolFilterTest {
       "http://www.mulesoft.org/schema/mule/core",
       "http://www.mulesoft.org/schema/mule/http",
 
+      // Well-known identifier URLs — XMPP protocol namespaces and Xerces/JAXP XML parser features
+      "http://jabber.org/protocol/muc",
+      "http://jabber.org/protocol/disco#items",
+      "http://jabber.org/protocol/pubsub#owner",
+      "http://apache.org/xml/features/nonvalidating/load-dtd-grammar",
+      "http://apache.org/xml/features/nonvalidating/load-external-dtd",
+
       // Single-label hostnames — cannot resolve on the public internet
       "http://local-kubernetes-hostname/something",
       "http://local-kubernetes-hostname:8080/something",
@@ -341,6 +348,13 @@ class CleartextProtocolFilterTest {
       "http://schema.org.evil.com/Person",
       "http://www.mulesoft.org.evil.com/schema",
       "http://10.0.2.2.evil.com",
+
+      // Well-known identifier URLs — host without the safe path, or lookalike host — must not match
+      "http://jabber.org/",
+      "http://jabber.org/other",
+      "http://apache.org/",
+      "http://apache.org/xml/features/nonvalidating/load-dtd-grammar-extra",
+      "http://apache.org.evil.com/xml/features/nonvalidating/load-dtd-grammar",
 
       // Adjacent /24 ranges outside the Android emulator network — must not match
       "http://10.0.1.2/",

--- a/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
+++ b/commons/src/test/java/org/sonarsource/analyzer/commons/appsec/CleartextProtocolFilterTest.java
@@ -222,6 +222,13 @@ class CleartextProtocolFilterTest {
       "http://jabber.org/protocol/pubsub#owner",
       "http://apache.org/xml/features/nonvalidating/load-dtd-grammar",
       "http://apache.org/xml/features/nonvalidating/load-external-dtd",
+      "http://apache.org/xml/features/disallow-doctype-decl",
+      "http://apache.org/xml/features/dom/create-entity-ref-nodes",
+
+      // Well-known identifier URLs with a template placeholder — URI parsing fails,
+      // lenient fallback must still recognise the safe path prefix
+      "http://jabber.org/protocol/${node}",
+      "http://apache.org/xml/features/${feature}",
 
       // Single-label hostnames — cannot resolve on the public internet
       "http://local-kubernetes-hostname/something",
@@ -353,8 +360,10 @@ class CleartextProtocolFilterTest {
       "http://jabber.org/",
       "http://jabber.org/other",
       "http://apache.org/",
-      "http://apache.org/xml/features/nonvalidating/load-dtd-grammar-extra",
+      "http://apache.org/xml/featuresx/disallow-doctype-decl",
       "http://apache.org.evil.com/xml/features/nonvalidating/load-dtd-grammar",
+      // Template placeholder with a path outside the safe prefix — lenient fallback must not grant safety
+      "http://jabber.org/other/${x}",
 
       // Adjacent /24 ranges outside the Android emulator network — must not match
       "http://10.0.1.2/",


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

## What
`CleartextProtocolFilter` now recognises a new category of well-known identifier URLs: specific `http://` URLs (or URL prefixes) that are opaque protocol/feature identifiers rather than real network endpoints, on hosts that also serve ordinary content:

- `http://jabber.org/protocol/*` — XMPP protocol namespaces (XEPs)
- `http://apache.org/xml/features/nonvalidating/load-dtd-grammar`
- `http://apache.org/xml/features/nonvalidating/load-external-dtd`
  (Xerces/JAXP XML parser features to disable DTD loading)

## Why
These are used as opaque literal identifiers (XML namespace URIs / XML parser feature-flag URIs) in source code, never as actual network requests, so flagging them as insecure cleartext protocol usage is a false positive.

## How
Unlike the existing `NAMESPACE_URI_AUTHORITIES` list (matched on host only), `jabber.org` and `apache.org` also serve ordinary content outside these specific paths, so a new `SAFE_URL_PATH_PREFIXES` pattern matches on host + path instead. Added positive and boundary-negative test cases (bare host, near-miss suffix, lookalike host) to `CleartextProtocolFilterTest`.

## Testing
`mvn -pl commons -am test -Dtest=CleartextProtocolFilterTest` → 214 tests, 0 failures.